### PR TITLE
Add an install.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Finally, please remember that *Pacu is a BETA product.* Please be mindful of thi
 
 ## Installation
 
-Pacu is a fairly lightweight program, as it requires only [Python3.6+](https://www.python.org/downloads/) and pip3 to install a handful of Python libraries.
+Pacu is a fairly lightweight program, as it requires only [Python3.6+](https://www.python.org/downloads/) and pip3 to install a handful of Python libraries. Running install.sh will check your Python version and ensure all Python packages are up to date.
 
 ## Quick Installation
 
 ```
   > git clone https://github.com/RhinoSecurityLabs/pacu
   > cd pacu
-  > pip3 install -r requirements.txt
+  > sh install.sh
   > python3 pacu.py
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+check_python_version() {
+    echo "[ + ] Checking Python version . . ."
+    echo "[ $ ] python3 --version"
+
+    PYTHON_VERSION=$(python3 --version)
+
+    echo "$PYTHON_VERSION"
+
+    # This ensures the Python version is 3.6 or higher. https://regex101.com/
+    VERSION_REGEX="Python\ ((3\.[^0-5])|(3\.[1-9][0-9]+)|([4-9]+\.\d+))"
+
+    if [[ $PYTHON_VERSION =~ $VERSION_REGEX ]]; then
+        echo "[ + ] Your Python version is compatible with Pacu."
+    else
+        echo "\\033[38;5;202m[ - ] Pacu requires Python to be installed at version $MINIMUM_VERSION or higher to run properly. Your version is: $PYTHON_VERSION"
+        echo "Please install Python version 3.6 or higher. \\033[38;5;33mhttps://www.python.org/downloads/\\033[38;5;00m"
+        exit 1
+    fi
+}
+
+install_pip_requirements() {
+    echo "[ + ] Installing Pacu's Python package dependencies . . ."
+    echo "[ $ ] pip3 install -r requirements.txt"
+
+    PIP_OUTPUT=$(pip3 install -r requirements.txt)
+    PIP_ERROR_CODE=$?
+
+    echo "$PIP_OUTPUT"
+
+    if [ $PIP_ERROR_CODE = '0' ]; then
+        echo "[ + ] Pip install finished. (exit $PIP_ERROR_CODE)"
+    else
+        echo "\\033[38;5;202m[ - ] Pip raised an error while installing Pacu's Python package dependencies."
+        echo "All Python packages used by Pacu should be installed before pacu.py is run."
+        echo "It may be helpful to try running \`pip install -r requirements.txt\` directly."
+        echo "For assistance troubleshooting pip installation problems, please provide the"
+        echo "developers with as much information about this error as possible, including all"
+        echo "text output by install.sh. (exit $PIP_ERROR_CODE)\\033[38;5;00m"
+        exit 1
+    fi
+}
+
+check_python_version
+install_pip_requirements


### PR DESCRIPTION
The install.sh script provides assistance and advice to users when installing or checking Pacu's Python version and pip-managed packages. It also provides a basic level of debugging output for detecting Python and package issues.