### PR TITLE
Bug/type error cred report

### DIFF
--- a/modules/get_credential_report/main.py
+++ b/modules/get_credential_report/main.py
@@ -79,6 +79,9 @@ def main(args, pacu_main):
                 print('Access Denied for get_credential_report')
                 report = None
                 break
+            else:
+                print(f"Unrecognized ClientError: {str(error)} ({error.response['Error']['Code']})")
+                break
 
     if report and 'Content' in report:
         if not os.path.exists(f'sessions/{session.name}/downloads'):
@@ -89,6 +92,9 @@ def main(args, pacu_main):
             csv_file.write(report['Content'].decode())
 
         print(f'Credential report saved to {filename}')
+
+    else:
+        print('\n  Unable to generate report.\n')
 
     print(f"{module_info['name']} completed.\n")
     return


### PR DESCRIPTION
Difficulty testing live because of a 4 hour window where a generated report will return True. Tested with Moto and raising custom exceptions.

Tested with 3 different sets of permissions regarding credential reports:
1. Without get
2. Without generate
3. Without either

1. Simply fails and exits the module
2. Should allow you to enter the get report loop, but will fail out when you try to generate a report and the module completes without trying to write the report.
3. Same as 1.

Also tested if there is no report and you don't want to generate a new one. Exits the loop and doesn't attempt to write to file. 

Also tested waiting and ensuring that the loop continues until the report is found