### PR TITLE
Permission & Usage fixes

### DIFF
--- a/modules/aws__enum_account/main.py
+++ b/modules/aws__enum_account/main.py
@@ -52,7 +52,11 @@ def main(args, pacu_main):
 
     iam_client = pacu_main.get_boto3_client('iam')
     response = iam_client.list_account_aliases()
-    account_iam_alias = response['AccountAliases'][0]
+    try:
+        account_iam_alias = response['AccountAliases'][0]
+    except (KeyError, IndexError):
+        account_iam_alias = "<No IAM Alias defined>"
+
     print('Enumerating Account: {}'.format(account_iam_alias))
     # All the billing seems to be in us-east-1. YMMV
     cwm_client = pacu_main.get_boto3_client('cloudwatch', "us-east-1")
@@ -79,12 +83,25 @@ def main(args, pacu_main):
         else:
             account_spend = response['Datapoints'][0]['Maximum']
     except ClientError as e:
-        print("ClientError getting spend: {}".format(e))
-        account_spend = "unavailable"
+        if e.response['Error']['Code'] == "AccessDenied":
+            account_spend = "<unauthorized>"
+        else:
+            print("Unable to get Spend Data: {}".format(e))
+            account_spend = "<ClientError>"
 
-    org_client = pacu_main.get_boto3_client('organizations')
-    org_response = org_client.describe_organization()
-    org_data = org_response['Organization']
+
+    try:
+        org_client = pacu_main.get_boto3_client('organizations')
+        org_response = org_client.describe_organization()
+        org_data = org_response['Organization']
+    except ClientError as e:
+        org_data = {}
+        if e.response['Error']['Code'] == "AccessDeniedException":
+            org_data['error'] = "Not Authorized to get Organization Data"
+        else:
+            print("Unable to get Organization Data: {}".format(e))
+            org_data['error'] = "Error Getting Organization Data"
+
 
     account_data = {
         'account_id': account_id,

--- a/modules/aws__enum_spend/main.py
+++ b/modules/aws__enum_spend/main.py
@@ -66,6 +66,7 @@ def main(args, pacu_main):
             return
     except ClientError as e:
         print("ClientError getting spend: {}".format(e))
+        return({ "error": "<unauthorized>"})
 
     for s in services:
         try:

--- a/modules/ec2__startup_shell_script/main.py
+++ b/modules/ec2__startup_shell_script/main.py
@@ -77,6 +77,9 @@ def main(args, pacu_main):
     instances = []
     if args.instance_ids is not None:  # need to update this to include the regions of these IDs
         for instance in args.instance_ids.split(','):
+            if "@" not in instance:
+                print("Usage: <instance-id>@<region>   ex: i-abcdef12345@us-west-2")
+                return({"error": "invalid usage"})
             instances.append({
                 'InstanceId': instance.split('@')[0],
                 'Region': instance.split('@')[1]

--- a/modules/iam__privesc_scan/main.py
+++ b/modules/iam__privesc_scan/main.py
@@ -497,7 +497,7 @@ def main(args, pacu_main):
 
             for perm in user_escalation_methods[method]:
                 if user_escalation_methods[method][perm] is True:  # If this permission is required
-                    if 'PermissionsConfirmed' in user and user['PermissionsConfirmed'] is True:  # If permissions are confirmed
+                    if 'PermissionsConfirmed' in target and target['PermissionsConfirmed'] is True:  # If permissions are confirmed
                         if perm not in checked_perms['Allow']:  # If this permission isn't Allowed, then this method won't work
                             potential = confirmed = False
                             break


### PR DESCRIPTION
While executing pacu against a CloudGoat environment, I discovered a few permission issues with my two enum modules, and then kept getting the startup_shell_script module usage wrong. This PR fixes those issues. d