### PR TITLE
Bug/fix python regex

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ check_python_version() {
     echo "$PYTHON_VERSION"
 
     # This ensures the Python version is 3.6 or higher. https://regex101.com/
-    VERSION_REGEX="Python\ ((3\.[^0-4])|(3\.[1-9][0-9]+)|([4-9]+\.\d+))"
+    VERSION_REGEX="Python\ ((3\.[^0-4])|(3\.[1-9][0-9]+)|([4-9]+\.\d+)).*"
 
     if [[ $PYTHON_VERSION =~ $VERSION_REGEX ]]; then
         echo "[ + ] Your Python version is compatible with Pacu."

--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,12 @@ check_python_version() {
     echo "[ $ ] python3 --version"
 
     MINIMUM_VERSION="3.5"
-    PYTHON_VERSION=$(python3 --version)
+    PYTHON_VERSION=$(python3 --version 2>&1)
 
     echo "$PYTHON_VERSION"
 
     # This ensures the Python version is 3.6 or higher. https://regex101.com/
-    VERSION_REGEX="Python\ ((3\.[^0-4])|(3\.[1-9][0-9]+)|([4-9]+\.\d+)).*"
+    VERSION_REGEX="^Python\ ((3\.[^0-4])|(3\.[1-9][0-9]+)|([4-9]+\.\d+))(.*)$"
 
     if [[ $PYTHON_VERSION =~ $VERSION_REGEX ]]; then
         echo "[ + ] Your Python version is compatible with Pacu."


### PR DESCRIPTION
Had some issues with install script in that Regex didn't match additional string output in the case of using Anaconda version of Python.

Also, had issue with `$(python3 --version)` output not being in `PYTHON_VERSION` variable, redirected stderr and stdout and that fixed that issue as well.

<img width="872" alt="screen shot 2018-11-25 at 8 02 13 pm" src="https://user-images.githubusercontent.com/1680159/48998387-6d87ba00-f0f7-11e8-9f90-c04a459b1bff.png">
