### PR TITLE
Revert requirements.txt urllib3 version to 1.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ s3transfer==0.1.13
 flake8==3.5.0
 pytz==2018.5
 requests==2.18.4
-urllib3~=1.23
+urllib3==1.22
 SQLAlchemy==1.2.8
 SQLAlchemy-Utils==0.33.3


### PR DESCRIPTION
The requests package at version 2.18.4 raises errors internally if
the version of urllib3 available to it is anything other than 1.22.
The security patch introduced in urllib3 v1.23 does not affect Pacu's
use of the requests package, so this reversion will be used until the
requests package is updated.

References: https://nvd.nist.gov/vuln/detail/CVE-2018-20060
https://github.com/requests/requests/blob/master/Pipfile.lock#L56