### PR TITLE
Add cloudwatch logs enumeration to iam__bruteforce_permissions module

### DIFF
--- a/modules/iam__bruteforce_permissions/main.py
+++ b/modules/iam__bruteforce_permissions/main.py
@@ -35,7 +35,8 @@ parser.add_argument(
 
 SUPPORTED_SERVICES = [
     'ec2',
-    's3'
+    's3',
+    'logs'
 ]
 
 current_client = None


### PR DESCRIPTION
Allows for bruteforce enumeration to include cloudwatch logs api.

A common mistake for lambda function roles is to include * for cloudwatch logs permissions as the lambda function name determines cloudwatch log group. If lambda function leaks credentials this is useful for detecting services that are likely to be "open".