### PR TITLE
Fixing aws__enum_spend when account uses too many services

### DIFF
--- a/modules/aws__enum_spend/main.py
+++ b/modules/aws__enum_spend/main.py
@@ -108,6 +108,6 @@ def main(args, pacu_main):
 
 def summary(data, pacu_main):
     out = "Account Spend:\n"
-    for key in data.keys():
-        out += "        {}: {} (USD)\n".format(key, data[key])
+    for key in sorted(data.keys(), key=lambda x: data[x], reverse=True):
+        out += "        {:<30}: {:>10.2f} (USD)\n".format(key, data[key])
     return out

--- a/pacu.py
+++ b/pacu.py
@@ -1110,8 +1110,8 @@ class Main:
                 # If the module's return value is None, it exited early.
                 if summary_data is not None:
                     summary = module.summary(summary_data, self)
-                    if len(summary) > 1000:
-                        raise ValueError('The {} module\'s summary is too long ({} characters). Reduce it to 1000 characters or fewer.'.format(module.module_info['name'], len(summary)))
+                    if len(summary) > 10000:
+                        raise ValueError('The {} module\'s summary is too long ({} characters). Reduce it to 10000 characters or fewer.'.format(module.module_info['name'], len(summary)))
                     if not isinstance(summary, str):
                         raise TypeError(' The {} module\'s summary is {}-type instead of str. Make summary return a string.'.format(module.module_info['name'], type(summary)))
                     self.print('{} completed.\n'.format(module.module_info['name']))


### PR DESCRIPTION
When there's more than about 40 services used, the output of the aws__enum_spend module can exceed the pacu-defined 1000 character limit and die.  

This patch raises the limit to 10,000 characters, formats the output into columns, and sorts the output by amount spent in descending order.
