### PR TITLE
Fixed keyError

### DIFF
--- a/modules/codebuild__enum/main.py
+++ b/modules/codebuild__enum/main.py
@@ -90,7 +90,6 @@ def main(args, pacu_main):
 
                
             while 'nextToken' in response:
-                response = {}
                 try:
                     response = client.list_builds(
                         nextToken=response['nextToken']


### PR DESCRIPTION
Clearing the response object raises an exception, as it is used in the next function call, client.list_builds(...). As it is reassigned in the subsequent line, just removing it is the simplest, and best, solution.