### PR TITLE
Add iam__pivot integrated

### DIFF
--- a/modules/iam__enum_users_roles_policies_groups/main.py
+++ b/modules/iam__enum_users_roles_policies_groups/main.py
@@ -36,6 +36,7 @@ parser.add_argument('--users', required=False, action='store_true', help='Enumer
 parser.add_argument('--roles', required=False, action='store_true', help='Enumerate info for roles in the account')
 parser.add_argument('--policies', required=False, action='store_true', help='Enumerate info for policies in the account')
 parser.add_argument('--groups', required=False, action='store_true', help='Enumerate info for groups in the account')
+parser.add_argument('--instance-profiles', required=False, action='store_true', help='Enumerate info for instance profiles in the account')
 
 
 def main(args, pacu_main):
@@ -143,6 +144,32 @@ def main(args, pacu_main):
         iam_data['Policies'] = policies
         session.update(pacu_main.database, IAM=iam_data)
         summary_data['Policies'] = len(policies)
+
+    if args.instance_profiles is True:
+        instance_profiles = []
+        response = None
+        is_truncated = False
+
+        try:
+            while response is None or is_truncated is True:
+                if is_truncated is False:
+                    response = client.list_instance_profiles()
+                else:
+                    response = client.list_instance_profiles(Marker=response['Marker'])
+                for profiles in response['InstanceProfiles']:
+                    instance_profiles.append(profiles)
+
+                is_truncated = response['IsTruncated']
+            print('Found {} instance profiles'.format(len(instance_profiles)))
+
+        except ClientError:
+            print('No Instance Profiles Found')
+            print('  FAILURE: MISSING NEEDED PERMISSIONS')
+
+        iam_data = deepcopy(session.IAM)
+        iam_data['InstanceProfiles'] = instance_profiles
+        session.update(pacu_main.database, IAM=iam_data)
+        summary_data['InstanceProfiles'] = len(instance_profiles)
 
     if args.groups is True:
         groups = []

--- a/modules/iam__pivot/common/__init__.py
+++ b/modules/iam__pivot/common/__init__.py
@@ -1,0 +1,1 @@
+from .escalation import Escalation

--- a/modules/iam__pivot/common/escalation.py
+++ b/modules/iam__pivot/common/escalation.py
@@ -1,0 +1,19 @@
+from typing import Callable
+
+from principalmapper.common import Edge, Node
+
+
+class Escalation(Edge):
+    def __init__(self, source: Node, destination: Node, escalate_func: Callable, reason: str = None):
+        self.reason = reason or "can access via {}".format(str(escalate_func))
+
+        super().__init__(source=source, destination=destination, reason=self.reason)
+
+        self.source = source
+        self.destination = destination
+        self.escalate_func = escalate_func
+
+    def run(self, *args, **kwargs):
+        kwargs["source"] = self.source
+        kwargs["target"] = self.destination
+        self.escalate_func(*args, **kwargs)

--- a/modules/iam__pivot/escalation/__init__.py
+++ b/modules/iam__pivot/escalation/__init__.py
@@ -1,4 +1,1 @@
-#from .iam_checker import IamEscalationChecker
-#from .sts_checker import StsEscalationChecker
-
 from .assume_role import *

--- a/modules/iam__pivot/escalation/__init__.py
+++ b/modules/iam__pivot/escalation/__init__.py
@@ -1,0 +1,4 @@
+#from .iam_checker import IamEscalationChecker
+#from .sts_checker import StsEscalationChecker
+
+from .assume_role import *

--- a/modules/iam__pivot/escalation/assume_role.py
+++ b/modules/iam__pivot/escalation/assume_role.py
@@ -1,0 +1,48 @@
+from typing import Iterator
+
+from modules.iam__pivot.common import Escalation
+
+from principalmapper.querying import query_interface as query
+from principalmapper.querying.local_policy_simulation import resource_policy_authorization as resource_policy_auth
+from principalmapper.querying.query_interface import Node, ResourcePolicyEvalResult, has_matching_statement
+from principalmapper.util import arns
+from .sts_checker import StsEscalationChecker
+
+
+class AssumeRole(StsEscalationChecker):
+    def setup(self):
+        self.required_source_actions = ['sts:AssumeRole']
+        self.required_dest_trust_policy_actions = ['sts:AssumeRole']
+
+    def run(self, pacu_main, source, target):
+        print("Assuming Role: " + target.arn)
+        sts = pacu_main.get_boto3_client('sts')
+        creds = sts.assume_role(RoleArn=target.arn, RoleSessionName="pacu")['Credentials']
+        pacu_main.set_keys(target.searchable_name(), creds['AccessKeyId'], creds['SecretAccessKey'], creds['SessionToken'])
+
+    def escalations(self, source: Node, dest: Node) -> Iterator[Escalation]:
+        # Check against resource policy
+        sim_result = resource_policy_auth(source, arns.get_account_id(source.arn), dest.trust_policy, 'sts:AssumeRole', dest.arn, {}, debug=False)
+
+        assume_auth, need_mfa = query.local_check_authorization_handling_mfa(source, 'sts:AssumeRole', dest.arn, {})
+        policy_denies = has_matching_statement(source, 'Deny', 'sts:AssumeRole', dest.arn, {})
+        policy_denies_mfa = has_matching_statement(source, 'Deny', 'sts:AssumeRole', dest.arn, {
+            'aws:MultiFactorAuthAge': '1',
+            'aws:MultiFactorAuthPresent': 'true'
+        })
+
+        if assume_auth:
+            if need_mfa:
+                reason = '(requires MFA) can access via sts:AssumeRole'
+            else:
+                reason = 'can access via sts:AssumeRole'
+
+            new_esc = Escalation(source, dest, escalate_func=self.run, reason=reason)
+            print('Found new edge: {}\n'.format(new_esc.describe_edge()))
+            yield new_esc
+        elif not (policy_denies_mfa and policy_denies) and sim_result == ResourcePolicyEvalResult.NODE_MATCH:
+            # testing same-account scenario, so NODE_MATCH will override a lack of an allow from iam policy
+            new_esc = Escalation(source, dest, escalate_func=NotImplementedError, reason='can access via sts:AssumeRole')
+            print('Found new edge: {}\n'.format(new_esc.describe_edge()))
+
+            yield new_esc

--- a/modules/iam__pivot/escalation/escalation_checker.py
+++ b/modules/iam__pivot/escalation/escalation_checker.py
@@ -1,0 +1,100 @@
+import abc
+import itertools
+
+import io
+import os
+
+from typing import List, Iterator
+
+import botocore
+
+from modules.iam__pivot.common import Escalation
+
+from principalmapper.graphing.edge_checker import EdgeChecker
+from principalmapper.common import Node, Policy
+from principalmapper.querying.local_policy_simulation import policy_has_matching_statement, \
+    policies_include_matching_allow_action
+
+policy_allow_all = Policy("arn:aws:iam::922105094392:policy/policy_allow_all", "policy_allow_all", {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::*:role/*"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+})
+
+
+class EscalationChecker(EdgeChecker):
+    identity = None
+
+    def __init__(self, session: botocore.session.Session):
+        self.session = session
+        self.required_dest_trust_policy_actions: List = []
+        self.required_source_actions: List = []
+
+        # If True stop looking for path's once we find an admin role
+        self.filter_source_admin: bool = True
+
+    @classmethod
+    def _setup(cls, self):
+        """Since __init__ will be called for every subclass, cache anything expensive as class attributes here."""
+        sts = self.session.create_client('sts')
+        cls.identity = sts.get_caller_identity()
+
+    def setup(self):
+        """SubClasses can set various config options here without needing to override __init__() and call super()"""
+        pass
+
+    @abc.abstractmethod
+    def escalations(self, source: Iterator[Node], dest: Iterator[Node]) -> Iterator[Escalation]:
+        """By default we call can_escalate_to_role and can_escalate_to_user for each source/dest
+        you can override this and/or ignore both can_escalate_to_role and can_escalate_to_user
+        if you want.
+        """
+
+    def _filter_sources(self, source: Node) -> bool:
+        """ Uses the Config dataclass to filter nodes from being sent to subclasses, filtering is done in the base class
+        to avoid O(N^2) processing on the size of the node list.
+        """
+        if self.filter_source_admin and source.is_admin:
+            return False
+
+        for action in self.required_source_actions:
+            if not policies_include_matching_allow_action(source, action):
+                return False
+
+        return True
+
+    def _filter_dests(self, dest: Node) -> bool:
+        for action in self.required_dest_trust_policy_actions:
+            if not policy_has_matching_statement(policy_allow_all, 'Allow', action, dest, {}) \
+                    or policy_has_matching_statement(policy_allow_all, 'Deny', action, dest, {}):
+                return False
+
+        if ':user/' in dest.arn or dest.arn == self.identity["Arn"]:
+            return False
+
+        return True
+
+    def _subclass_escalations(self, srcs: Iterator[Node], dsts: Iterator[Node]) -> Iterator[Escalation]:
+        self._setup(self)
+        for sub_cls in self.__class__.__subclasses__():
+            inst = sub_cls(self.session)
+            inst.setup()
+
+            # Use sub_cls's filters before we run product to avoid O(N^2) processing on the size of the node list.
+            srcs = filter(inst._filter_sources, srcs)
+            dsts = filter(inst._filter_dests, dsts)
+
+            for source, dest in itertools.product(srcs, dsts):
+                yield from inst.escalations(source, dest)
+
+    def return_edges(self, nodes: List[Node], output: io.StringIO = io.StringIO(os.devnull), debug: bool = False) -> \
+            List[Escalation]:
+        return list(self._subclass_escalations(iter(nodes.copy()), iter(nodes.copy())))

--- a/modules/iam__pivot/escalation/sts_checker.py
+++ b/modules/iam__pivot/escalation/sts_checker.py
@@ -1,0 +1,5 @@
+from .escalation_checker import EscalationChecker
+
+
+class StsEscalationChecker(EscalationChecker):
+    pass

--- a/modules/iam__pivot/graph.py
+++ b/modules/iam__pivot/graph.py
@@ -1,0 +1,162 @@
+import io
+import os
+
+import botocore.session
+import principalmapper
+from core.models import PacuSession
+from principalmapper.common import Node, Group, Policy, Graph
+from principalmapper.graphing import edge_identification, gathering
+from principalmapper.querying import query_interface
+from principalmapper.util import arns
+from principalmapper.util.debug_print import dprint
+from typing import List, Optional, TextIO
+
+
+def create_graph(session: PacuSession, aws_session: botocore.session.Session, service_list: list, output: TextIO = open(os.devnull),
+                 debug=False) -> Graph:
+    """Constructs a Graph object.
+
+    Information about the graph as it's built will be written to the IO parameter `output`.
+    """
+    stsclient = aws_session.create_client('sts')
+    caller_identity = stsclient.get_caller_identity()
+    dprint(debug, "Caller Identity: {}".format(caller_identity['Arn']))
+    metadata = {
+        'account_id': caller_identity['Account'],
+        'pmapper_version': principalmapper.__version__
+    }
+
+    iamclient = aws_session.create_client('iam')
+
+    # Gather users and roles, generating a Node per user and per role
+    nodes_result = get_unfilled_nodes(session, iamclient, output, debug)
+
+    # Gather groups from current list of nodes (users), generate Group objects, attach to nodes in-flight
+    groups_result = get_unfilled_groups(session, iamclient, nodes_result, output, debug)
+
+    # Resolve all policies, generate Policy objects, attach to all groups and nodes
+    policies_result = gathering.get_policies_and_fill_out(iamclient, nodes_result, groups_result, output, debug)
+
+    # Determine which nodes are admins and update node objects
+    gathering.update_admin_status(nodes_result, output, debug)
+
+    # Generate edges, generate Edge objects
+    edges_result = edge_identification.obtain_edges(aws_session, service_list, nodes_result, output, debug)
+
+    return Graph(nodes_result, edges_result, policies_result, groups_result, metadata)
+
+
+def get_unfilled_nodes(session: PacuSession, iamclient, output: io.StringIO = os.devnull, debug=False) -> List[Node]:
+    """Using an IAM.Client object, return a list of Node object for each IAM user and role in an account.
+
+    Does not set Group or Policy objects. Those have to be filled in later.
+
+    Writes high-level information on progress to the output file
+    """
+    result = []
+    # Get users, paginating results, still need to handle policies + group memberships + is_admin
+    output.write("Obtaining IAM users in account\n")
+    for user in session.IAM["Users"]:
+        result.append(Node(
+            arn=user['Arn'],
+            id_value=user['UserId'],
+            attached_policies=[],
+            group_memberships=[],
+            trust_policy=None,
+            instance_profile=None,
+            num_access_keys=0,
+            active_password='PasswordLastUsed' in user,
+            is_admin=False
+        ))
+        dprint(debug, 'Adding Node for user ' + user['Arn'])
+
+    # Get roles, paginating results, still need to handle policies + is_admin
+    output.write("Obtaining IAM roles in account\n")
+    for role in session.IAM['Roles']:
+        result.append(Node(
+            arn=role['Arn'],
+            id_value=role['RoleId'],
+            attached_policies=[],
+            group_memberships=[],
+            trust_policy=role['AssumeRolePolicyDocument'],
+            instance_profile=None,
+            num_access_keys=0,
+            active_password=False,
+            is_admin=False
+        ))
+
+    try:
+        # Get instance profiles, paginating results, and attach to roles as appropriate
+        output.write("Obtaining EC2 instance profiles in account\n")
+        for iprofile in session.IAM['InstanceProfiles']:
+            iprofile_arn = iprofile['Arn']
+            role_arns = []
+            for role in iprofile['Roles']:
+                role_arns.append(role['Arn'])
+            for node in result:
+                if ':role/' in node.arn and node.arn in role_arns:
+                    node.instance_profile = iprofile_arn
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'AccessDenied':
+            output.write("Access denied for ListInstanceProfiles.. continuing anyways\n")
+        else:
+            raise e
+
+    try:
+        # Handle access keys
+        output.write("Obtaining Access Keys data for IAM users\n")
+        for node in result:
+            if arns.get_resource(node.arn).startswith('user/'):
+                # Grab access-key count and update node
+                user_name = arns.get_resource(node.arn)[5:]
+                if '/' in user_name:
+                    user_name = user_name.split('/')[-1]
+                    dprint(debug, 'removed path from username {}'.format(user_name))
+                access_keys_data = iamclient.list_access_keys(UserName=user_name)
+                node.access_keys = len(access_keys_data['AccessKeyMetadata'])
+                dprint(debug, 'Access Key Count for {}: {}'.format(user_name, len(access_keys_data['AccessKeyMetadata'])))
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'AccessDenied':
+            output.write("Access denied for ListAccessKeys.. continuing anyways\n")
+        else:
+            raise e
+
+    return result
+
+
+def get_unfilled_groups(session, iamclient, nodes: List[Node], output: io.StringIO = os.devnull, debug=False) -> List[Group]:
+    """Using an IAM.Client object, returns a list of Group objects. Adds to each passed Node's group_memberships
+    property.
+
+    Does not set Policy objects. Those have to be filled in later.
+
+    Writes high-level progress information to parameter output
+    """
+    result = []
+
+    # paginate through groups and build result
+    output.write("Obtaining IAM groups in the account.\n")
+    for group in session.IAM['Groups']:
+        result.append(Group(
+            arn=group['Arn'],
+            attached_policies=[]
+        ))
+
+    # loop through group memberships
+    output.write("Connecting IAM users to their groups.\n")
+    for node in nodes:
+        if not arns.get_resource(node.arn).startswith('user/'):
+            continue  # skip when not an IAM user
+        dprint(debug, 'finding groups for user {}'.format(node.arn))
+        user_name = arns.get_resource(node.arn)[5:]
+        if '/' in user_name:
+            user_name = user_name.split('/')[-1]
+            dprint(debug, 'removed path from username {}'.format(user_name))
+        group_list = iamclient.list_groups_for_user(UserName=user_name)
+        for group in group_list['Groups']:
+            for group_obj in result:
+                if group['Arn'] == group_obj.arn:
+                    node.group_memberships.append(group_obj)
+
+    return result
+

--- a/modules/iam__pivot/main.py
+++ b/modules/iam__pivot/main.py
@@ -28,7 +28,7 @@ module_info = {
 # Every module must include an ArgumentParser named "parser", even if it
 # doesn't use any additional arguments.
 parser = argparse.ArgumentParser(add_help=False, description=json.dumps(module_info['description']))
-parser.add_argument('--rebuild-db', required=False, default=True, action='store_true',
+parser.add_argument('--rebuild-db', required=False, default=False, action='store_true',
                     help='Rebuild db used in this module, this will not affect other modules. This is needed to pick '
                          'up new or changed permissions.')
 
@@ -50,9 +50,10 @@ def main(args, pacu_main):
         ['IAM'], 'iam__enum_users_roles_policies_groups', '--users --roles --policies --groups --instance-profiles'
     )
     if iam_data is False:
-        print('FAILURE')
-        print('  SUB-MODULE EXECUTION FAILED')
-        return
+        print('FAILURE'
+              '  SUB-MODULE EXECUTION FAILED'
+              '  Will attempt to continue anyways'
+              )
 
     principalmapper.graphing.gathering.edge_identification.checker_map = checker_map
 

--- a/modules/iam__pivot/main.py
+++ b/modules/iam__pivot/main.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+import json
+import os
+import sys
+
+import boto3
+
+import principalmapper.common
+from modules.iam__pivot.escalation import StsEscalationChecker
+from modules.iam__pivot.graph import create_graph
+from principalmapper.graphing import graph_actions
+from principalmapper.querying.query_utils import get_search_list
+from principalmapper.graphing import gathering
+from principalmapper.common import Graph
+
+module_info = {
+    'name': 'pivot',
+    'author': 'Ryan Gerstenkorn',
+    'category': 'ESCALATE',
+    'one_liner': 'Pivots current user based on IAM data.',
+    'description': 'Updates aws_key info based on existing data found through other modules. Currently this looks for '
+                   'roles that can be assumed and allows you to pivot to them for the current user.',
+    'services': ['IAM'],
+}
+
+# Every module must include an ArgumentParser named "parser", even if it
+# doesn't use any additional arguments.
+parser = argparse.ArgumentParser(add_help=False, description=json.dumps(module_info['description']))
+parser.add_argument('--rebuild-db', required=False, default=True, action='store_true',
+                    help='Rebuild db used in this module, this will not affect other modules. This is needed to pick '
+                         'up new or changed permissions.')
+
+
+def main(args, pacu_main):
+    args = parser.parse_args(args)
+    session = pacu_main.get_active_session()
+    print = pacu_main.print
+    input = pacu_main.input
+    aws_sess = pacu_main._get_boto3_session()
+
+    permissions_data = pacu_main.fetch_data(None, 'iam__enum_permissions', [], force=True)
+    if permissions_data is False:
+        print('FAILURE')
+        print('  SUB-MODULE EXECUTION FAILED')
+        return
+
+    iam_data = pacu_main.fetch_data(
+        ['IAM'], 'iam__enum_users_roles_policies_groups', '--users --roles --policies --groups --instance-profiles'
+    )
+    if iam_data is False:
+        print('FAILURE')
+        print('  SUB-MODULE EXECUTION FAILED')
+        return
+
+    principalmapper.graphing.gathering.edge_identification.checker_map = checker_map
+
+    graph_path = os.path.abspath("./sessions/{}/pmapper".format(session.name))
+    os.makedirs(graph_path, 0o0700, True)
+    if args.rebuild_db or not os.path.exists(graph_path):
+        graph = create_graph(session, aws_session=aws_sess._session, service_list=['sts'], output=sys.stdout, debug=False)
+        graph.store_graph_as_json(graph_path)
+    else:
+        graph = graph_actions.get_graph_from_disk(graph_path)
+
+    source_node = get_current_node(graph, pacu_main.key_info())
+    data = collections.OrderedDict()
+    for edge_list in get_search_list(graph, source_node):
+        data[edge_list[-1]] = edge_list
+
+    if not data:
+        return False
+
+    target = ask_for_target(data, input, print)
+
+    # TODO: construct summary from each target response
+    for edge in data[target]:
+        edge.run(pacu_main)
+
+    return target.destination
+
+
+checker_map = {
+    'sts': StsEscalationChecker,
+}
+
+
+def summary(data, pacu_main):
+    if not data:
+        return "No assumable roles found"
+    return "KeyAlias: {} RoleArn: {}".format(pacu_main.key_info()["KeyAlias"], data.arn)
+
+
+def sess_from_h(user) -> boto3.session.Session:
+    return boto3.session.Session(aws_access_key_id=user['AccessKeyId'], aws_secret_access_key=user['SecretAccessKey'],
+                                 aws_session_token=user['SessionToken'])
+
+
+def get_current_node(graph: Graph, user):
+    if user["UserName"]:
+        source_name = 'user/{}'.format(user["UserName"])
+    elif user["RoleName"]:
+        source_name = 'role/{}'.format(user["RoleName"])
+    else:
+        raise UserWarning("No current user or role found")
+
+    return graph.get_node_by_searchable_name(source_name)
+
+
+def ask_for_target(data, input, print):
+    keys = list(data.keys())
+    item = 1
+    for target, edge_list in data.items():
+        print("    ({}) {}".format(item, target.destination.searchable_name()))
+        for edge in edge_list:
+            print("          * {} -> {} -> {}".format(edge.source.arn, edge.reason, edge.destination.arn))
+        print("          * {} is the target".format(edge.destination.arn))
+        item += 1
+    response = int(input("Choose role to assume: "))
+    target = keys[response - 1]
+    return target

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests==2.20.0
 urllib3==1.24.2
 SQLAlchemy==1.3.6
 SQLAlchemy-Utils==0.33.3
+principalmapper==1.0.1


### PR DESCRIPTION
This is the integrated version of iam__pivot, it is an attempt to use
 both existing data sources and expose an interface of iam__pivot in
a way that allows us to integrate more escalations.

For a simpler version of this without integration to pacu see
the feature/iam__pivot--basic branch.

One of the idea for this branch is that escalations in iam__privesc
could be included here over time and work alongside the current assume
role escalation.

 i.e you could be presented a path like:

user1 ---           can assume           ---> role2
role2 --- can exploit and gain access to ---> user3
user3 ---           can assume           ---> admin

along with several other's and pick which one you want to traverse.

Checker selection functionality:

  Although this isn't exposed to the user currently adding it
  should be fairly simple with how the integration currently
  works, that is, provided there is more functionality then
  just the sts assume role checker.

  Instead of using seperate checkers we currently have one root class
  which right now is the only one attached to checker_map. We track
  checkers via cls.__subclasses__ which can in turn either be a proxy
  to a larger group of checkers or be a checker it self.

  So attaching a subchecker works the same way as attaching the root,
  and a subchecker can simply use `pass` to act as a group of
  other checkers. In this sense we have a simple way to enable
  escalation checkers in groups, specifically or both.

Performance Improvements:

  Building the graph is already pretty slow, checkers run at O(n),
  while node size is O(n^2) or around there. We'll be adding more
  checker's with this approach, but we can reduce the run time
  by doing a simple precheck's before we make source/dest pairs
  out of the nodes. This is handled through filter_source and
  filter_dest methods.

  In a sense this is a declarative approach to specifying what
  is needed for the escalation to succeed. It may make sense
  to do this where ever possible to simplify in general things
  as well as take advantage of performance improvements like
  mentioned above.

Drawbacks:
  This all sounds great but to get this all to work I had to
  integrate it with pmapper in an unusual way and some of the
  code had to simply be copied to work in a way I needed it
  to.

  I don't think this makes sense, which to be honest is
  more of a gut feeling then anything, to merge this the
  way it is implemented now.

Options:
  To be honest I'm not sure what to do here. After messing
  around with this a bit I feel there's simply more
  important things to focus on in pacu. Maybe over the
  long term it could make sense to integrate some of
  the ideas here into pacu core but at the moment I'm
  not sure what that would look like.

  Anyways this is an interesting proof of concept if
  nothing else.