### PR TITLE
Add iam__pivot basic

### DIFF
--- a/modules/iam__pivot/main.py
+++ b/modules/iam__pivot/main.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+
+import boto3
+from principalmapper.common import Graph
+from principalmapper.graphing import graph_actions
+from principalmapper.querying.query_utils import get_search_list
+
+module_info = {
+    'name': 'iam_pivot',
+    'author': 'Ryan Gerstenkorn',
+    'category': 'ESCALATE',
+    'one_liner': 'Pivots current user based on IAM data.',
+    'description': 'Updates aws_key info based on existing data found through other modules. Currently this looks for '
+                   'roles that can be assumed and allows you to pivot to them for the current user.',
+    'services': ['IAM'],
+    'prerequisite_modules': ['iam_enum_permissions'],
+    'arguments_to_autocomplete': ['--rebuild-db'],
+}
+
+# Every module must include an ArgumentParser named "parser", even if it
+# doesn't use any additional arguments.
+parser = argparse.ArgumentParser(add_help=False, description=module_info['description'])
+parser.add_argument('--rebuild-db', required=False, default=False, action='store_true',
+                    help='Rebuild db used in this module, this will not affect other modules. This is needed to pick '
+                         'up new or changed permissions.')
+
+
+def main(args, pacu_main):
+    session = pacu_main.get_active_session()
+    args = parser.parse_args(args)
+    print = pacu_main.print
+    input = pacu_main.input
+    key_info = pacu_main.key_info
+
+    user = key_info()
+
+
+
+    if pacu_main.fetch_data(['IAM'], 'iam_enum_permissions', '') is False:
+        print('Pre-req module not run successfully. Continuing anyways')
+
+
+    root = 'sessions/{}/pmmapper'.format(session.name)
+    sess = pacu_main._get_boto3_session()
+
+
+    graph = get_graph(sess, root, args.rebuild_db)
+
+    if user["UserName"]:
+        source_name = 'user/{}'.format(user["UserName"])
+    elif user["RoleName"]:
+        source_name = 'role/{}'.format(user["RoleName"])
+    else:
+        raise UserWarning("No current user or role found, you can try rebuilding the db with --rebuild-db to pick up " \
+                          "new IAM resources or use swap_keys to try with a different user.")
+
+    source_node = graph.get_node_by_searchable_name(source_name)
+    if not source_node:
+        raise UserWarning("could not find current user")
+
+    data = collections.OrderedDict()
+    for edge_list in get_search_list(graph, source_node):
+        data[edge_list[-1]] = edge_list
+
+    if not data:
+        return False
+
+    target = ask_for_target(data, input, print)
+
+    for edge in data[target]:
+        print("Assuming Role: " + edge.destination.arn)
+        creds = sess.client('sts').assume_role(RoleArn=edge.destination.arn, RoleSessionName="pacu")['Credentials']
+        sess = sess_from_h(creds)
+        pacu_main.set_keys(edge.destination.searchable_name(), creds['AccessKeyId'], creds['SecretAccessKey'],
+                           creds['SessionToken'])
+
+    return target.destination
+
+
+def summary(data, pacu_main):
+    if not data:
+        return "No assumable roles found"
+    return "KeyAlias: {} RoleArn: {}".format(pacu_main.key_info()["KeyAlias"], data.arn)
+
+
+def sess_from_h(user) -> boto3.session.Session:
+    return boto3.session.Session(aws_access_key_id=user['AccessKeyId'], aws_secret_access_key=user['SecretAccessKey'],
+                                 aws_session_token=user['SessionToken'])
+
+def get_graph(sess, root, rebuild: bool = False):
+    if rebuild:
+        graph = rebuild_db(sess, root)
+    else:
+        try:
+            graph = graph_actions.get_graph_from_disk(root)
+        except ValueError:
+            rebuild_db(sess, root)
+            graph = graph_actions.get_graph_from_disk(root)
+    return graph
+
+def rebuild_db(sess, root) -> Graph:
+    graph = graph_actions.create_new_graph(sess._session, ['sts'])
+    graph.store_graph_as_json(root)
+    return graph
+
+def ask_for_target(data, input, print):
+    keys = list(data.keys())
+    item = 1
+    for target, edge_list in data.items():
+        print("    ({}) {}".format(item, target.destination.searchable_name()))
+        for edge in edge_list:
+            print("          * {} -> {} -> {}".format(edge.source.arn, edge.reason, edge.destination.arn))
+        print("          * {} is the target".format(edge.destination.arn))
+        item += 1
+    response = int(input("Choose role to assume: "))
+    target = keys[response - 1]
+    return target

--- a/pacu.py
+++ b/pacu.py
@@ -16,7 +16,10 @@ import argparse
 try:
     import requests
     import boto3
+    from  boto3 import resource
     import botocore
+    import botocore.config
+    import botocore.session
     import urllib.parse
 
     import configure_settings
@@ -1309,14 +1312,31 @@ aws_secret_access_key = {}
                 self.print('  User agent for this session set to:')
                 self.print('    {}'.format(new_ua))
 
-    def get_boto3_client(self, service, region=None, user_agent=None, parameter_validation=True):
+    # _get_boto3_session is marked as private because it isn't able to set some of the same global
+    # settings get_boto3_client and get_boto3_resource are able to, currently this is just the
+    # user agent.
+    def _get_boto3_session(self, region=None) -> boto3.session.Session:
         session = self.get_active_session()
 
         if not session.access_key_id:
-            print('  No access key has been set. Failed to generate boto3 Client.')
-            return
+            raise UserWarning('  No access key has been set. Failed to generate boto3 Client.')
         if not session.secret_access_key:
-            print('  No secret key has been set. Failed to generate boto3 Client.')
+            raise UserWarning('  No secret key has been set. Failed to generate boto3 Client.')
+
+        return boto3.session.Session(
+            aws_access_key_id=session.access_key_id,
+            aws_secret_access_key=session.secret_access_key,
+            aws_session_token=session.session_token,
+            region_name=region,
+        )
+
+    def get_boto3_client(self, service, region=None, user_agent=None, parameter_validation=True):
+        session = self.get_active_session()
+
+        try:
+            aws_sess = self._get_boto3_session(region=region)
+        except UserWarning as e:
+            print(e.args)
             return
 
         # If there is not a custom user_agent passed into this function
@@ -1332,7 +1352,7 @@ aws_secret_access_key = {}
             parameter_validation=parameter_validation
         )
 
-        return boto3.client(
+        return aws_sess.client(
             service,
             region_name=region,  # Whether region has a value or is None, it will work here
             aws_access_key_id=session.access_key_id,
@@ -1345,11 +1365,10 @@ aws_secret_access_key = {}
         # All the comments from get_boto3_client apply here too
         session = self.get_active_session()
 
-        if not session.access_key_id:
-            print('  No access key has been set. Failed to generate boto3 Resource.')
-            return
-        if not session.secret_access_key:
-            print('  No secret key has been set. Failed to generate boto3 Resource.')
+        try:
+            aws_sess = self._get_boto3_session(region=region)
+        except UserWarning as e:
+            print(e.args)
             return
 
         if user_agent is None and session.boto_user_agent is not None:
@@ -1360,13 +1379,15 @@ aws_secret_access_key = {}
             parameter_validation=parameter_validation
         )
 
-        return boto3.resource(
+        return aws_sess.resource(
             service,
+
             region_name=region,
             aws_access_key_id=session.access_key_id,
             aws_secret_access_key=session.secret_access_key,
             aws_session_token=session.session_token,
             config=boto_config
+
         )
 
     def initialize_tab_completion(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests==2.20.0
 urllib3==1.24.2
 SQLAlchemy==1.3.6
 SQLAlchemy-Utils==0.33.3
+principalmapper==1.0.1


### PR DESCRIPTION
This uses pmmapper to build a graph db of escalation routes and
gives you the option of which one to traverse.

This only checks for assume role but can be extended to check for
other escalations.

This version of the module is fairly basic and doesn't attempt to
integrate with pacu, which means it won't know about previously
found resources and pacu won't know about any resources pmapper
finds.

For a different take on this same module see
features/iam__pivot-integrated.