### PR TITLE
Minimal fix when enumerating NotResource

### DIFF
--- a/modules/iam__enum_permissions/main.py
+++ b/modules/iam__enum_permissions/main.py
@@ -581,10 +581,16 @@ def parse_document(document, user):
                             user['Permissions']['Allow'][action]['Resources'].append(statement['Resource'])
                     else:
                         user['Permissions']['Allow'][action] = {'Resources': [], 'Conditions': []}
-                        if isinstance(statement['Resource'], list):
+                        resource = statement.get('Resource')
+                        if isinstance(resource, list):
                             user['Permissions']['Allow'][action]['Resources'] = statement['Resource']
-                        else:
+                        elif resource:
                             user['Permissions']['Allow'][action]['Resources'] = [statement['Resource']]
+                        else:
+                            identity = user.get('UserName') or user.get('RoleName')
+                            print("[WARN] No 'Resource' section found. The policy for {} likely contains NotResource "
+                                  "and our recorded permissions on it will likely be incomplete.".format(identity))
+
                     if 'Condition' in statement:
                             user['Permissions']['Allow'][action]['Conditions'].append(statement['Condition'])
                     user['Permissions']['Allow'][action]['Resources'] = list(set(user['Permissions']['Allow'][action]['Resources']))  # Remove duplicate resources


### PR DESCRIPTION
# Problem
Running `run iam__enum_permissions --all-users --all-roles` when a policy contains a NotResource action will cause it to fail.

# Notes
This just prevents Pacu from erroring out when it can likely complete the rest of the polices. There's likely other code path's this will happen on but I'm not able to test those at the moment, think we'll just have to fix them as they come up, or until we can rewrite this code.

# Related
Fixes #224 