### PR TITLE
Adding typing-extensions dep

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ flake8==3.8.4
 mypy==0.790
 sqlalchemy-stubs==0.3
 pytest==6.2.1
+typing-extensions==3.7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests==2.25.1
 urllib3==1.26.3
 SQLAlchemy==1.3.22
 SQLAlchemy-Utils==0.36.8
+typing-extensions==3.7.4.3


### PR DESCRIPTION
typing-extensions is not listed in requirements.txt causing Pacu to crash after installing. Added the dep to be installed on setup. 

Fixes issue #233 