### PR TITLE
Fix ecs__enum_task_def datetime serialization

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -1,6 +1,6 @@
 from sqlalchemy import orm
 
-from utils import stringify_datetime
+from utils import stringify
 
 
 class ModelUpdateMixin:
@@ -12,7 +12,7 @@ class ModelUpdateMixin:
             session.update(database, field_name={'json': ...}) """
 
         for key, value in kwargs.items():
-            value = stringify_datetime(value)
+            value = stringify(value)
             setattr(self, key, value)
 
         database.add(self)

--- a/modules/ecs__enum_task_def/main.py
+++ b/modules/ecs__enum_task_def/main.py
@@ -84,7 +84,7 @@ def main(args, pacu_main):
             formatted_data = "{}@{}\n{}\n\n".format(
                 task_def,
                 region,
-                json.dumps(task_def_data['taskDefinition'], indent=4)
+                json.dumps(task_def_data['taskDefinition'], indent=4, default=str)
             )
            
             with open('sessions/{}/downloads/ecs_task_def_data/all_task_def.txt'.format(session.name), 'a+') as data_file:

--- a/utils.py
+++ b/utils.py
@@ -61,7 +61,7 @@ def stringify(obj: Union[dict, list, datetime]) -> Union[dict, list, str]:
         return str(obj.strftime("%a, %d %b %Y %H:%M:%S"))
 
     elif isinstance(obj, bytes):
-        # If obj is a datetime, return a formatted string version of it
+        # If obj is bytes, return a formatted string version of it
         return obj.decode()
 
     else:

--- a/utils.py
+++ b/utils.py
@@ -35,30 +35,34 @@ def remove_empty_from_dict(d: Union[dict, list, typing.Any]) -> Union[dict, list
         return d
 
 
-def stringify_datetime(obj: Union[dict, list, datetime]) -> Union[dict, list, str]:
+def stringify(obj: Union[dict, list, datetime]) -> Union[dict, list, str]:
     """ The sqlalchemy-utils' JSONType doesn't accept Python datetime objects.
     This method converts all datetime objects in JSONizable data structures
     into strings, allowing the ORM to save them. """
 
     if isinstance(obj, dict):
         # If obj is a dict, iterate over its items and recusrively call
-        # stringify_datetime on each of them.
+        # stringify on each of them.
         new_dict = dict()
         for k, v in obj.items():
-            new_dict[k] = stringify_datetime(v)
+            new_dict[k] = stringify(v)
         return new_dict
 
     elif isinstance(obj, list):
         # If obj is a list, iterate over its elements and recusrively call
-        # stringify_datetime on each of them.
+        # stringify on each of them.
         new_list = list()
         for v in obj:
-            new_list.append(stringify_datetime(v))
+            new_list.append(stringify(v))
         return new_list
 
     elif isinstance(obj, datetime):
         # If obj is a datetime, return a formatted string version of it
         return str(obj.strftime("%a, %d %b %Y %H:%M:%S"))
+
+    elif isinstance(obj, bytes):
+        # If obj is a datetime, return a formatted string version of it
+        return obj.decode()
 
     else:
         return obj


### PR DESCRIPTION
The datetime object in the ecs task def response causes serialization to fail without setting a default method.

This change sets the default to str.