### PR TITLE
Added 'data' command accepts case insensitive service name

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -685,12 +685,13 @@ class Main:
             self.print('\nSession data:')
             session.print_all_data_in_session()
         else:
-            if command[1] not in session.aws_data_field_names:
+            service = command[1].upper()
+            if service not in session.aws_data_field_names:
                 print('  Service not found.')
-            elif getattr(session, command[1]) == {} or getattr(session, command[1]) == [] or getattr(session, command[1]) == '':
+            elif getattr(session, service) == {} or getattr(session, service) == [] or getattr(session, service) == '':
                 print('  No data found.')
             else:
-                print(json.dumps(getattr(session, command[1]), indent=2, sort_keys=True, default=str))
+                print(json.dumps(getattr(session, service), indent=2, sort_keys=True, default=str))
 
     def parse_set_regions_command(self, command):
         session = self.get_active_session()


### PR DESCRIPTION
It's more convenient if 'data' command accepts both upper case and lower case services name 