### PR TITLE
Fix for users.json files not getting populated

### DIFF
--- a/pacu/modules/iam__enum_permissions/main.py
+++ b/pacu/modules/iam__enum_permissions/main.py
@@ -458,7 +458,7 @@ def main(args, pacu_main: 'Main'):
                         deny_permissions=user['Permissions']['Deny']
                     )
                 else:
-                    with save('confirmed_permissions/user-{}.json'.format(session.name, user['UserName']), 'w+') as f:
+                    with save('confirmed_permissions/user-{}.json'.format(user['UserName']), 'w+') as f:
                         json.dump(user, f, indent=2, default=str)
 
                     print('    Permissions stored in user-{}.json'.format(user['UserName']))


### PR DESCRIPTION
I noticed that `run iam__privesc_scan --offline` was only reporting on roles and not users.  Digging into it, I realized that user json files were not getting written to  `~.local/share/pacu/test/downloads/confirmed_permissions/` when `iam__enum_permissions` is run with the `--all-users` flag, while the roles.json files were getting written.  

It looks like the only difference is this `session.name`. Once I removed it, everything worked as expected.  I ran `run iam__enum_permissions --all-users` and the user json files were written at which point `run iam__privesc_scan --offline` reported on both users and roles.  Easy fix for my use case, but I haven't done any other testing to see if this breaks something else. 