### PR TITLE
fix pacu_dir not return '/home/user/.local/lib/python3.8/pacu'

### DIFF
--- a/pacu/core/lib.py
+++ b/pacu/core/lib.py
@@ -22,7 +22,7 @@ def home_dir() -> Path:
 
 
 def pacu_dir() -> Path:
-    return Path(__file__).parents[2]
+    return Path(__file__).parents[1]
 
 
 def session_dir() -> Path:

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -459,7 +459,7 @@ class Main:
         TIME_FORMAT = '%Y-%m-%d'
         UPDATE_CYCLE = 7  # Days
         UPDATE_INFO_PATH = lib.home_dir()/'update_info.json'
-        LAST_UPDATE_PATH = lib.pacu_dir()/'pacu/last_update.txt'
+        LAST_UPDATE_PATH = lib.pacu_dir()/'last_update.txt'
         UPDATE_MSG = '''Pacu has a new version available! Clone it from GitHub to receive the updates.
         git clone https://github.com/RhinoSecurityLabs/pacu.git'''
 

--- a/tests/test_pacu_update.py
+++ b/tests/test_pacu_update.py
@@ -17,8 +17,7 @@ def test_fresh_install(pacu_dir, home_dir, get, tmp_path):
     pacu_dir.return_value = tmp_path
     home_dir.return_value = tmp_path
     get.return_value.text = '2021-01-01'
-    (tmp_path/'pacu/').mkdir()
-    with open(tmp_path/'pacu/last_update.txt', 'w') as f:
+    with open(tmp_path/'last_update.txt', 'w') as f:
         f.write('2021-01-01')
 
     with freeze_time('2021-01-01'):
@@ -40,8 +39,7 @@ def test_one_month_no_update(pacu_dir, home_dir, get, tmp_path):
     pacu_dir.return_value = tmp_path
     home_dir.return_value = tmp_path
     get.return_value.text = '2021-01-01'
-    (tmp_path/'pacu/').mkdir()
-    with open(tmp_path/'pacu/last_update.txt', 'w') as f:
+    with open(tmp_path/'last_update.txt', 'w') as f:
         f.write('2021-01-01')
 
     update_info = {
@@ -64,8 +62,7 @@ def test_one_month_updatable(pacu_dir, home_dir, get, tmp_path):
     pacu_dir.return_value = tmp_path
     home_dir.return_value = tmp_path
     get.return_value.text = '2021-02-01'
-    (tmp_path/'pacu/').mkdir()
-    with open(tmp_path/'pacu/last_update.txt', 'w') as f:
+    with open(tmp_path/'last_update.txt', 'w') as f:
         f.write('2021-01-01')
 
     update_info = {
@@ -92,8 +89,7 @@ def test_one_month_updatable(pacu_dir, home_dir, get, tmp_path):
 def test_local_updatable(pacu_dir, home_dir, get, tmp_path):
     pacu_dir.return_value = tmp_path
     home_dir.return_value = tmp_path
-    (tmp_path/'pacu/').mkdir()
-    with open(tmp_path/'pacu/last_update.txt','w') as f:
+    with open(tmp_path/'last_update.txt','w') as f:
         f.write('2021-01-01')
 
     update_info = {

--- a/tests/test_pacu_utils.py
+++ b/tests/test_pacu_utils.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+from pacu.core.lib import pacu_dir
+
+
+def test_pacu_dir():
+    assert str(pacu_dir()) == str(Path(__file__).parents[1]/'pacu')
+


### PR DESCRIPTION
If install pacu via pip pacu_dir() will return  `/home/user/.local/lib/python3.8/site-packages` 
this PR fix pacu_dir() to return `/home/user/.local/lib/python3.8/site-packages/pacu`

I found this when trying to fixes a bug on #284