### PR TITLE
add a data command sub service filter

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -88,7 +88,7 @@ def display_pacu_help():
         whoami                              Display information regarding to the active access keys
         data                                Display all data that is stored in this session. Only fields
                                               with values will be displayed
-        data <service>                      Display all data for a specified service in this session
+        data <service> [<sub-service>]      Display all data for a specified service in this session
         services                            Display a list of services that have collected data in the
                                               current session to use with the "data" command
         regions                             Display a list of all valid AWS regions

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -719,7 +719,7 @@ class Main:
         else:
             self.print(self._parse_data_command(command, session))
 
-    def _parse_data_command(self, command: List[str], session: 'PacuSession') -> str:
+    def _parse_data_command(self, command: List[str], session: PacuSession) -> str:
         service = command[1].upper()
         service_map = dict([(key.upper(), key) for key in session.aws_data_field_names])
         name = service_map.get(service.upper())
@@ -740,13 +740,12 @@ class Main:
         name = sub_service_map.get(sub_service.upper())
 
         if not name or name not in service_data.keys():
-            return '  Sub-service not found. Please use the Sub-service name below.\n' + \
+            return '  Sub-service not found. Please use the sub-service name below.\n' + \
                    '\t'.join(service_data.keys())
         elif not service_data[name]:
             return '  No data found.'
         else:
             return json.dumps(service_data[name], indent=2, sort_keys=True, default=str)
-
 
     def parse_set_regions_command(self, command):
         session = self.get_active_session()

--- a/tests/test_pacu_data_command.py
+++ b/tests/test_pacu_data_command.py
@@ -1,0 +1,114 @@
+import pytest
+from sqlalchemy import orm, create_engine
+from sqlalchemy.orm import sessionmaker
+from pacu import settings, Main
+from pacu import core
+from pacu.core.models import PacuSession
+
+@pytest.fixture(scope='function')
+def db() -> core.base:
+    # Recreate the engine and session maker each run
+    core.base.engine: Engine = create_engine(settings.DATABASE_CONNECTION_PATH)
+    core.base.Session: sessionmaker = sessionmaker(bind=core.base.engine)
+    core.base.Base.metadata.create_all(core.base.engine)
+    yield core.base.Session()
+
+@pytest.fixture(scope='function')
+def pacu(db):
+    pacu = Main()
+    pacu.database = db
+    return pacu
+
+@pytest.fixture(scope='function')
+def active_session(db, pacu_session: PacuSession):
+    pacu_session.activate(db)
+    yield pacu_session
+
+@pytest.fixture(scope='function')
+def pacu_session(db: orm.session.Session):
+    query: orm.Query = db.query(PacuSession)
+    assert query.count() == 0
+
+    pacu_session = PacuSession()
+    db.add(pacu_session)
+    yield pacu_session
+
+def test_parse_data_command_returns_help(pacu: Main, active_session: PacuSession):
+    msg = pacu._parse_data_command(['data', 'non-existent-service'], active_session)
+    assert 'Service not found. Please use the service name below.' in msg
+    assert 'APIGateway	CloudTrail	CloudWatch	CodeBuild	Config' in msg
+
+
+def test_parse_data_command_returns_no_data_found(pacu: Main, active_session: PacuSession):
+    msg = pacu._parse_data_command(['data', 'CloudWatch'], active_session)
+    assert 'No data found' in msg
+
+
+def test_parse_data_command_returns_no_data_found_case_insensitive(pacu: Main, active_session: PacuSession):
+    msg = pacu._parse_data_command(['data', 'cloudwatch'], active_session)
+    assert 'No data found' in msg
+
+
+@pytest.fixture(scope='function')
+def pacu_with_data(pacu: Main, active_session: PacuSession):
+    active_session.update(pacu.database, CloudWatch={"test_key": "test_value"})
+    return pacu
+
+
+def test_parse_data_command_returns_data(pacu_with_data: Main, active_session: PacuSession):
+    msg = pacu_with_data._parse_data_command(['data', 'CloudWatch'], active_session)
+    assert 'test_key' in msg
+    assert 'test_value' in msg
+
+
+def test_parse_data_command_returns_data_case_insensitive(pacu_with_data: Main, active_session: PacuSession):
+    msg = pacu_with_data._parse_data_command(['data', 'cloudwatch'], active_session)
+    assert 'test_key' in msg
+    assert 'test_value' in msg
+
+
+service_data = {
+        'lowercase_key': 'lowercase_key_value',
+        'UPERCASE_KEY': 'upercase_key_value',
+        'MixCase_Key': 'mixcase_key_value',
+        'no_data_key': None
+    }
+
+
+def test_parse_data_command_sub_service_returns_help(pacu:Main):
+    msg = pacu._parse_data_command_sub_service(service_data, 'non_existent_sub_service')
+    assert 'Sub-service not found. Please use the sub-service name below.' in msg
+    assert 'lowercase_key\tUPERCASE_KEY\tMixCase_Key\tno_data_key' in msg
+
+
+def test_parse_data_command_sub_service_lowercase(pacu:Main):
+    msg = pacu._parse_data_command_sub_service(service_data, 'lowercase_key')
+    assert '"lowercase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'upercase_key')
+    assert '"upercase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'mixcase_key')
+    assert '"mixcase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'no_data_key')
+    assert '  No data found.' == msg
+
+
+def test_parse_data_command_sub_service_upercase(pacu:Main):
+    msg = pacu._parse_data_command_sub_service(service_data, 'LOWERCASE_KEY')
+    assert '"lowercase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'UPERCASE_KEY')
+    assert '"upercase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'MIXCASE_KEY')
+    assert '"mixcase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'NO_DATA_KEY')
+    assert '  No data found.' == msg
+
+
+def test_parse_data_command_sub_service_mixcase(pacu:Main):
+    msg = pacu._parse_data_command_sub_service(service_data, 'LowerCase_Key')
+    assert '"lowercase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'UperCase_Key')
+    assert '"upercase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'MixCase_Key')
+    assert '"mixcase_key_value"' == msg
+    msg = pacu._parse_data_command_sub_service(service_data, 'No_Data_Key')
+    assert '  No data found.' == msg

--- a/tests/test_pacu_session.py
+++ b/tests/test_pacu_session.py
@@ -3,7 +3,7 @@ from sqlalchemy import orm, create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
-from pacu import settings, Main
+from pacu import settings
 from pacu import core
 from pacu.core.models import PacuSession
 
@@ -48,44 +48,3 @@ def active_session(db, pacu_session: PacuSession):
 
 def test_active_session(active_session: PacuSession):
     assert active_session.is_active
-
-
-@pytest.fixture(scope='function')
-def pacu(db):
-    pacu = Main()
-    pacu.database = db
-    return pacu
-
-
-def test_parse_data_command_returns_help(pacu: Main, active_session: PacuSession):
-    msg = pacu._parse_data_command(['data', 'non-existent-service'], active_session)
-    assert 'Service not found. Please use the service name below.' in msg
-    assert 'APIGateway	CloudTrail	CloudWatch	CodeBuild	Config' in msg
-
-
-def test_parse_data_command_returns_no_data_found(pacu: Main, active_session: PacuSession):
-    msg = pacu._parse_data_command(['data', 'CloudWatch'], active_session)
-    assert 'No data found' in msg
-
-
-def test_parse_data_command_returns_no_data_found_case_insensitive(pacu: Main, active_session: PacuSession):
-    msg = pacu._parse_data_command(['data', 'cloudwatch'], active_session)
-    assert 'No data found' in msg
-
-
-@pytest.fixture(scope='function')
-def pacu_with_data(pacu: Main, active_session: PacuSession):
-    active_session.update(pacu.database, CloudWatch={"test_key": "test_value"})
-    return pacu
-
-
-def test_parse_data_command_returns_data(pacu_with_data: Main, active_session: PacuSession):
-    msg = pacu_with_data._parse_data_command(['data', 'CloudWatch'], active_session)
-    assert 'test_key' in msg
-    assert 'test_value' in msg
-
-
-def test_parse_data_command_returns_data_case_insensitive(pacu_with_data: Main, active_session: PacuSession):
-    msg = pacu_with_data._parse_data_command(['data', 'cloudwatch'], active_session)
-    assert 'test_key' in msg
-    assert 'test_value' in msg


### PR DESCRIPTION
printing all data in the service is too much information. this PR helps you scope which sub-service you want to lookup.

```console
Pacu (session:test) > data ec2 subnets
```