### PR TITLE
Feature/migrations

### DIFF
--- a/pacu/core/models.py
+++ b/pacu/core/models.py
@@ -5,13 +5,12 @@ import copy
 from sqlalchemy import (
     Boolean, Column, DateTime, ForeignKey, inspect, Integer, Text, orm
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, Session
 from sqlalchemy_utils import JSONType  # type: ignore
 
-from pacu.core.base import Base
+from pacu.core.base import Base, engine
 from pacu.core.mixins import ModelUpdateMixin
 from pacu.utils import remove_empty_from_dict
-from sqlalchemy.orm.session import Session
 
 
 class AWSKey(Base, ModelUpdateMixin):
@@ -64,6 +63,7 @@ class AWSKey(Base, ModelUpdateMixin):
         })
 
 
+
 class PacuSession(Base, ModelUpdateMixin):
     __tablename__ = 'pacu_session'
     aws_data_field_names = (
@@ -91,7 +91,7 @@ class PacuSession(Base, ModelUpdateMixin):
         'Account',
         'AccountSpend',
         'Route53',
-        'RDS'
+        'RDS',
     )
 
     aws_keys = relationship('AWSKey', back_populates='session', cascade='all, delete-orphan', lazy='dynamic')
@@ -144,9 +144,10 @@ class PacuSession(Base, ModelUpdateMixin):
         return '<PacuSession #{} ({}:{})>'.format(self.id, self.name, key_alias)
 
     @classmethod
-    def get_active_session(cls, database) -> 'PacuSession':
+    def get_active_session(cls, database: Session) -> 'PacuSession':
         # SQLAlchemy's query filters disallow the use of `cond is True`.
         return database.query(PacuSession).filter(PacuSession.is_active == True).scalar()  # noqa: E712
+
 
     def get_active_aws_key(self, database: Session) -> AWSKey:
         """ Return the AWSKey with the same key_alias as the PacuSession.
@@ -211,3 +212,23 @@ class PacuSession(Base, ModelUpdateMixin):
                     all_data[attribute.key] = attribute.value
 
         return remove_empty_from_dict(all_data)
+
+
+def migrations(database: 'Session'):
+    """Very hacky migrations for the pacu_session table.
+
+    This exists to prevent broken installs on update when modules add new columns to the PacuSession table. This will
+    only add columns that are included in PacuSession.aws_data_field_names and will assume the columns should be NOT
+    NULL.
+    """
+    db_svcs = []
+    for row in database.execute(f'pragma table_info({PacuSession.__tablename__})').fetchall():
+        db_svcs.append(row[1])
+
+    for svc in PacuSession.aws_data_field_names:
+        if svc not in db_svcs:
+            column = getattr(PacuSession, svc)
+            column_type = column.type.compile(engine.dialect)
+            database.execute('ALTER TABLE %s ADD COLUMN %s %s DEFAULT "{}" NOT NULL' % (PacuSession.__tablename__, svc, column_type))
+
+

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -29,7 +29,7 @@ try:
 
     from pacu import settings
 
-    from pacu.core.models import AWSKey, PacuSession
+    from pacu.core.models import AWSKey, PacuSession, migrations
     from pacu.setup_database import setup_database_if_not_present
     from sqlalchemy import exc, orm  # type: ignore
     from pacu.utils import get_database_connection, set_sigint_handler
@@ -1599,6 +1599,7 @@ aws_secret_access_key = {}
 
     def run_cli(self, *args) -> None:
         self.database = get_database_connection(settings.DATABASE_CONNECTION_PATH)
+        migrations(self.database)
         sessions: List[PacuSession] = self.database.query(PacuSession).all()
 
         arg = args[0]
@@ -1702,6 +1703,8 @@ aws_secret_access_key = {}
                     set_sigint_handler(exit_text=None, value='SIGINT called')
 
                     self.database = get_database_connection(settings.DATABASE_CONNECTION_PATH)
+
+                    migrations(self.database)
 
                     self.check_sessions()
 

--- a/tests/test_pacu_session.py
+++ b/tests/test_pacu_session.py
@@ -1,11 +1,13 @@
 import pytest
-from sqlalchemy import orm, create_engine
+import sqlalchemy.exc
+from sqlalchemy import orm, create_engine, Column
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy_utils import JSONType
 
 from pacu import settings, Main
 from pacu import core
-from pacu.core.models import PacuSession
+from pacu.core.models import PacuSession, migrations
 
 # Import base and models after settings are set up
 settings.DATABASE_CONNECTION_PATH = "sqlite:///:memory:"
@@ -22,6 +24,24 @@ def db() -> core.base:
 
 def test_sanity(db: orm.session.Session):
     assert PacuSession().__class__ == PacuSession
+
+
+@pytest.fixture(scope='function')
+def db_new_column(db: Session):
+    # Recreate the engine and session maker each run
+    PacuSession.TestSvc = Column(JSONType, nullable=False, default=dict)
+    PacuSession.aws_data_field_names = PacuSession.aws_data_field_names + ('TestSvc',)
+    core.base.Session: sessionmaker = sessionmaker(bind=core.base.engine)
+    yield core.base.Session()
+
+
+def test_migrations(db_new_column):
+    with pytest.raises(sqlalchemy.exc.OperationalError):
+        PacuSession.get_active_session(db_new_column)
+
+    migrations(db_new_column)
+
+    assert PacuSession.get_active_session(db_new_column) is None
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
This adds some basic support for migrations.

Currently if you add an modules for new services it will break Pacu on update because the DB schema has changed. The fix currently is to to delete and and recreate the database. This also is somewhat worse now with it using a common DB for all installs, can't just re-clone and have it work like normal again.