### PR TITLE
Support AWS log tagging with custom user agent suffix command

### DIFF
--- a/pacu/core/models.py
+++ b/pacu/core/models.py
@@ -103,6 +103,7 @@ class PacuSession(Base, ModelUpdateMixin):
     is_active = Column(Boolean, nullable=False, default=False)
     name = Column(Text)
     boto_user_agent = Column(Text)
+    user_agent_suffix=Column(Text)
     key_alias = Column(Text)
     access_key_id = Column(Text)
     secret_access_key = Column(Text)

--- a/pacu/core/models.py
+++ b/pacu/core/models.py
@@ -103,7 +103,7 @@ class PacuSession(Base, ModelUpdateMixin):
     is_active = Column(Boolean, nullable=False, default=False)
     name = Column(Text)
     boto_user_agent = Column(Text)
-    user_agent_suffix=Column(Text)
+    user_agent_suffix = Column(Text)
     key_alias = Column(Text)
     access_key_id = Column(Text)
     secret_access_key = Column(Text)

--- a/pacu/core/models.py
+++ b/pacu/core/models.py
@@ -241,6 +241,9 @@ def migrations(database: 'Session'):
         if svc not in rows:
             column = getattr(PacuSession, svc)
             column_type = column.type.compile(engine.dialect)
-            database.execute('ALTER TABLE %s ADD COLUMN %s %s DEFAULT "{}" NOT NULL' % (PacuSession.__tablename__, svc, column_type))
+            database.execute(
+                'ALTER TABLE %s ADD COLUMN %s %s DEFAULT "{}" NOT NULL' % 
+                (PacuSession.__tablename__, svc, column_type)
+            )
 
 

--- a/pacu/core/models.py
+++ b/pacu/core/models.py
@@ -242,8 +242,8 @@ def migrations(database: 'Session'):
             column = getattr(PacuSession, svc)
             column_type = column.type.compile(engine.dialect)
             database.execute(
-                'ALTER TABLE %s ADD COLUMN %s %s DEFAULT "{}" NOT NULL' % 
-                (PacuSession.__tablename__, svc, column_type)
+                'ALTER TABLE %s ADD COLUMN %s %s DEFAULT "{}" NOT NULL'
+                % (PacuSession.__tablename__, svc, column_type)
             )
 
 

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -1120,8 +1120,8 @@ aws_secret_access_key = {}
                   'modules where\n          regions are required, but not supplied by the user. The default set of regions is every supported\n          '
                   'region for the service. Supply "all" to this command to reset the region set to the default of all\n          supported regions\n')
         elif command_name == 'set_ua_suffix':
-            print('\n    set_ua_suffix [<suffix>]\n        Set the user agent suffix for this session. The suffix will be appended to the user agent for all API \n'
-                  '        calls. If no suffix is supplied a UUID-based suffix will be generated in the form Pacu-Session-<UUID>.\n')
+            print('\n    set_ua_suffix [<suffix>]\n        Set the user agent suffix for this session. The suffix will be appended to the user agent for all\n'
+                  '        API calls. If no suffix is supplied a UUID-based suffix will be generated in the form Pacu-Session-<UUID>.\n')
         elif command_name == 'unset_ua_suffix':
             print('\n    unset_ua_suffix\n        Remove the user agent suffix for this session\n')
         elif command_name == 'run' or command_name == 'exec':

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -1497,16 +1497,10 @@ aws_secret_access_key = {}
         if user_agent is None and session.boto_user_agent is not None:
             user_agent = session.boto_user_agent
 
-        if session.user_agent_suffix is not None:
-            # grab the botocore UA if none is specified yet
-            if user_agent is None:
-                boto3_session = boto3.session.Session()
-                user_agent = boto3_session._session.user_agent()
-            user_agent += (" " + session.user_agent_suffix)
-
         return botocore.config.Config(  # type: ignore[attr-defined]
             region_name=region,
             user_agent=user_agent,  # If user_agent=None, botocore will use the real UA which is what we want
+            user_agent_extra=session.user_agent_suffix,
             retries={
                 'max_attempts': 10,
                 'mode': 'adaptive',

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -102,8 +102,8 @@ def display_pacu_help():
                                               command to reset the region set to the default of all
                                               supported regions
         set_ua_suffix [<suffix>]            Set the user agent suffix for this session. The suffix will be 
-                                            appended to the user agent for all API calls. If no suffix is 
-                                            supplied a UUID-based suffix will be generated.
+                                              appended to the user agent for all API calls. If no suffix is 
+                                              supplied a UUID-based suffix will be generated.
         run/exec <module name>              Execute a module
         set_keys                            Add a set of AWS keys to the session and set them as the
                                               default
@@ -819,7 +819,7 @@ class Main:
     
     def parse_set_ua_suffix_command(self, command: List[str]) -> None:
         if len(command) == 1:
-            user_agent_suffix = f"Pacu-Session-{str(uuid.uuid4())}"
+            user_agent_suffix = f"Pacu-Session-{uuid.uuid4()}"
         elif len(command) == 2:
             user_agent_suffix = command[1]
         self.set_user_agent_suffix(user_agent_suffix)

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -644,6 +644,7 @@ class Main:
         elif command[0] == 'regions':
             self.display_all_regions()
         elif command[0] == 'run' or command[0] == 'exec':
+            self.print_user_agent_suffix()
             self.parse_exec_module_command(command)
         elif command[0] == 'search':
             self.parse_search_command(command)
@@ -823,9 +824,15 @@ class Main:
         elif len(command) == 2:
             user_agent_suffix = command[1]
         self.set_user_agent_suffix(user_agent_suffix)
+        self.print_user_agent_suffix()
 
     def set_user_agent_suffix(self, user_agent_suffix: str) -> None:
         self.get_active_session().update(self.database, user_agent_suffix=user_agent_suffix)
+    
+    def print_user_agent_suffix(self) -> None:
+        user_agent_suffix = self.get_active_session().user_agent_suffix 
+        if user_agent_suffix is not None:
+            print(f"Using user agent suffix {user_agent_suffix}")
 
     def update_regions(self) -> None:
         py_executable = sys.executable

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -104,6 +104,7 @@ def display_pacu_help():
         set_ua_suffix [<suffix>]            Set the user agent suffix for this session. The suffix will be 
                                               appended to the user agent for all API calls. If no suffix is 
                                               supplied a UUID-based suffix will be generated.
+        unset_ua_suffix                     Remove the user agent suffix for this session.
         run/exec <module name>              Execute a module
         set_keys                            Add a set of AWS keys to the session and set them as the
                                               default
@@ -174,7 +175,7 @@ class Main:
     COMMANDS = [
         'aws', 'data', 'exec', 'exit', 'help', 'import_keys', 'assume_role', 'list', 'load_commands_file',
         'ls', 'quit', 'regions', 'run', 'search', 'services', 'set_keys', 'set_regions',
-        'swap_keys', 'update_regions', 'set_ua_suffix', 'whoami', 'swap_session', 'sessions',
+        'swap_keys', 'update_regions', 'set_ua_suffix', 'unset_ua_suffix', 'whoami', 'swap_session', 'sessions',
         'list_sessions', 'delete_session', 'export_keys', 'open_console', 'console'
     ]
 
@@ -663,6 +664,8 @@ class Main:
             self.update_regions()
         elif command[0] == 'set_ua_suffix':
             self.parse_set_ua_suffix_command(command)
+        elif command[0] == 'unset_ua_suffix':
+            self.unset_user_agent_suffix()
         elif command[0] == 'whoami':
             self.print_key_info()
         elif command[0] == 'exit' or command[0] == 'quit':
@@ -828,6 +831,9 @@ class Main:
 
     def set_user_agent_suffix(self, user_agent_suffix: str) -> None:
         self.get_active_session().update(self.database, user_agent_suffix=user_agent_suffix)
+
+    def unset_user_agent_suffix(self) -> None:
+        self.get_active_session().update(self.database, user_agent_suffix=None)
     
     def print_user_agent_suffix(self) -> None:
         user_agent_suffix = self.get_active_session().user_agent_suffix 
@@ -1116,6 +1122,8 @@ aws_secret_access_key = {}
         elif command_name == 'set_ua_suffix':
             print('\n    set_ua_suffix [<suffix>]\n        Set the user agent suffix for this session. The suffix will be appended to the user agent for all API \n'
                   '        calls. If no suffix is supplied a UUID-based suffix will be generated in the form Pacu-Session-<UUID>.\n')
+        elif command_name == 'unset_ua_suffix':
+            print('\n    unset_ua_suffix\n        Remove the user agent suffix for this session\n')
         elif command_name == 'run' or command_name == 'exec':
             print('\n    run/exec <module name>\n        Execute a module\n')
         elif command_name == 'set_keys':

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -101,7 +101,9 @@ def display_pacu_help():
                                               every supported region for the service. Supply "all" to this
                                               command to reset the region set to the default of all
                                               supported regions
-        set_ua_suffix [<suffix>]            Set the user agent suffix for this session
+        set_ua_suffix [<suffix>]            Set the user agent suffix for this session. The suffix will be 
+                                            appended to the user agent for all API calls. If no suffix is 
+                                            supplied a UUID-based suffix will be generated.
         run/exec <module name>              Execute a module
         set_keys                            Add a set of AWS keys to the session and set them as the
                                               default
@@ -172,7 +174,7 @@ class Main:
     COMMANDS = [
         'aws', 'data', 'exec', 'exit', 'help', 'import_keys', 'assume_role', 'list', 'load_commands_file',
         'ls', 'quit', 'regions', 'run', 'search', 'services', 'set_keys', 'set_regions',
-        'swap_keys', 'update_regions', 'whoami', 'swap_session', 'sessions',
+        'swap_keys', 'update_regions', 'set_ua_suffix', 'whoami', 'swap_session', 'sessions',
         'list_sessions', 'delete_session', 'export_keys', 'open_console', 'console'
     ]
 
@@ -1105,7 +1107,8 @@ aws_secret_access_key = {}
                   'modules where\n          regions are required, but not supplied by the user. The default set of regions is every supported\n          '
                   'region for the service. Supply "all" to this command to reset the region set to the default of all\n          supported regions\n')
         elif command_name == 'set_ua_suffix':
-            print('\n    set_ua_suffix\n        Set the user agent suffix for this session\n')
+            print('\n    set_ua_suffix [<suffix>]\n        Set the user agent suffix for this session. The suffix will be appended to the user agent for all API \n'
+                  '        calls. If no suffix is supplied a UUID-based suffix will be generated in the form Pacu-Session-<UUID>.\n')
         elif command_name == 'run' or command_name == 'exec':
             print('\n    run/exec <module name>\n        Execute a module\n')
         elif command_name == 'set_keys':

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -101,8 +101,8 @@ def display_pacu_help():
                                               every supported region for the service. Supply "all" to this
                                               command to reset the region set to the default of all
                                               supported regions
-        set_ua_suffix [<suffix>]            Set the user agent suffix for this session. The suffix will be 
-                                              appended to the user agent for all API calls. If no suffix is 
+        set_ua_suffix [<suffix>]            Set the user agent suffix for this session. The suffix will be
+                                              appended to the user agent for all API calls. If no suffix is
                                               supplied a UUID-based suffix will be generated.
         unset_ua_suffix                     Remove the user agent suffix for this session.
         run/exec <module name>              Execute a module
@@ -820,7 +820,7 @@ class Main:
         elif len(command) >= 3:
             if command[1] in ('cat', 'category'):
                 self.list_modules(command[2], by_category=True)
-    
+
     def parse_set_ua_suffix_command(self, command: List[str]) -> None:
         if len(command) == 1:
             user_agent_suffix = f"Pacu-Session-{uuid.uuid4()}"
@@ -834,9 +834,9 @@ class Main:
 
     def unset_user_agent_suffix(self) -> None:
         self.get_active_session().update(self.database, user_agent_suffix=None)
-    
+
     def print_user_agent_suffix(self) -> None:
-        user_agent_suffix = self.get_active_session().user_agent_suffix 
+        user_agent_suffix = self.get_active_session().user_agent_suffix
         if user_agent_suffix is not None:
             print(f"Using user agent suffix {user_agent_suffix}")
 

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -1498,11 +1498,11 @@ aws_secret_access_key = {}
             user_agent = session.boto_user_agent
 
         if session.user_agent_suffix is not None:
-            user_agent_suffix = session.user_agent_suffix
+            # grab the botocore UA if none is specified yet
             if user_agent is None:
                 boto3_session = boto3.session.Session()
                 user_agent = boto3_session._session.user_agent()
-            user_agent += (" " + user_agent_suffix)
+            user_agent += (" " + session.user_agent_suffix)
 
         return botocore.config.Config(  # type: ignore[attr-defined]
             region_name=region,

--- a/pacu/settings.py
+++ b/pacu/settings.py
@@ -14,9 +14,7 @@ from pathlib import Path
 
 ERROR_LOG_VERBOSITY = 'minimal'
 
-# TODO: Restore this to the original path 
-#_home_dir = Path('~/.local/share/pacu')
-_home_dir = Path('~/.local/share/pacu_vectra')
+_home_dir = Path('~/.local/share/pacu')
 home_dir = _home_dir.expanduser().absolute()
 
 os.makedirs(home_dir, exist_ok=True, mode=0o700)

--- a/pacu/settings.py
+++ b/pacu/settings.py
@@ -14,7 +14,9 @@ from pathlib import Path
 
 ERROR_LOG_VERBOSITY = 'minimal'
 
-_home_dir = Path('~/.local/share/pacu')
+# TODO: Restore this to the original path 
+#_home_dir = Path('~/.local/share/pacu')
+_home_dir = Path('~/.local/share/pacu_vectra')
 home_dir = _home_dir.expanduser().absolute()
 
 os.makedirs(home_dir, exist_ok=True, mode=0o700)


### PR DESCRIPTION
This PR adds a new command to the interactive Pacu UI that allows a user to set a custom suffix that will be appended to all the user agent sent with all API calls. The intended purpose of this feature is to allow users to tag logs associated with actions they perform with different Pacu sessions.

If the user supplies a specific string, it will be appended along with a space to the end of the user agent. If no string is supplied, it will generate one from a UUID in the form `Pacu-Session-42c018ee-7bf1-4e83-ab83-9d9fdde059d4`.