### PR TITLE
Add in byte writeable option to fix s3 download

### DIFF
--- a/pacu/modules/s3__download_bucket/main.py
+++ b/pacu/modules/s3__download_bucket/main.py
@@ -78,7 +78,7 @@ def download_s3_file(pacu, key, bucket):
         if confirm != 'y':
             return False
     try:
-        with save(base_directory + key) as f:
+        with save(base_directory + key, 'wb') as f:
             s3.Bucket(bucket).download_fileobj(key, f)
     except Exception as error:
         pacu.print('  {}'.format(error))


### PR DESCRIPTION
Resolves #292 

Ran into the same error with message `write() argument must be str, not bytes`, fixed by specifying both modes in save call. 