### PR TITLE
cfn__resource_injection: Wrongly checking session id of victim as current session

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -608,11 +608,11 @@ class Main:
          PacuSession from the database, or None if no AWSKey
         with the supplied alias exists. If more than one key with the alias
         exists for the active session, an exception will be raised. """
-        session = self.get_active_session()
+        # session = self.get_active_session()
         key = self.database.query(AWSKey) \
             .filter(AWSKey.key_alias == alias) \
             .scalar()
-        return key    
+        return key
 
     # Pacu commands and execution
 

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -603,6 +603,17 @@ class Main:
             .scalar()
         return key
 
+    def get_aws_key_by_alias_from_db(self, alias: str) -> AWSKey:
+        """ Return an AWSKey with the supplied alias that is assigned to the
+         PacuSession from the database, or None if no AWSKey
+        with the supplied alias exists. If more than one key with the alias
+        exists for the active session, an exception will be raised. """
+        session = self.get_active_session()
+        key = self.database.query(AWSKey) \
+            .filter(AWSKey.key_alias == alias) \
+            .scalar()
+        return key    
+
     # Pacu commands and execution
 
     def parse_command(self, command):

--- a/pacu/modules/cfn__resource_injection/main.py
+++ b/pacu/modules/cfn__resource_injection/main.py
@@ -242,8 +242,6 @@ def deploy_lambda(pacu: 'Main', env: dict, deploy_dir: Path, bucket: str, princi
     print = pacu.print
 
     print(f"Will deploy lambda to {env['AWS_DEFAULT_REGION']}")
-    print((Path(__file__).parent / 'cfn__resource_injection_lambda'))
-    print(deploy_dir)
     if not deploy_dir.exists():
         shutil.copytree((Path(__file__).parent / 'cfn__resource_injection_lambda'), deploy_dir, dirs_exist_ok=False)
 

--- a/pacu/modules/cfn__resource_injection/main.py
+++ b/pacu/modules/cfn__resource_injection/main.py
@@ -192,7 +192,6 @@ def main(args, pacu_main: 'Main'):
         delete_lambda(deploy_dir, env)
     else:
         principal = principal
-        print(args.s3_access_key)
         s3_access_key: 'AWSKey' = pacu_main.get_aws_key_by_alias_from_db(args.s3_access_key)
         deploy_lambda(pacu_main, env, deploy_dir, bucket, principal, s3_access_key)
 
@@ -250,9 +249,6 @@ def deploy_lambda(pacu: 'Main', env: dict, deploy_dir: Path, bucket: str, princi
 
     config_path = deploy_dir / '.chalice' / 'config.json'
     config = json.loads(config_path.read_text())
-    print(s3_key)
-    print(principal)
-
     config['stages']['dev']['environment_variables']['PRINCIPAL'] = principal
     config['stages']['dev']['environment_variables']['BUCKET'] = bucket
     config['stages']['dev']['environment_variables']['S3_AWS_ACCESS_KEY_ID'] = s3_key.access_key_id

--- a/pacu/modules/cfn__resource_injection/main.py
+++ b/pacu/modules/cfn__resource_injection/main.py
@@ -178,7 +178,7 @@ def main(args, pacu_main: 'Main'):
     if args.bucket:
         bucket = args.bucket
     else:
-        sess = get_session_from_key_name(pacu_main, args.s3_access_key, 'us-east-1')
+        sess = get_aws_key_by_name(pacu_main, args.s3_access_key, 'us-east-1')
         bucket = get_bucket_name(sess.resource('s3'), lambda_dir)
 
     deploy_key: 'AWSKey' = pacu_main.get_aws_key_by_alias(args.attacker_key)
@@ -192,11 +192,12 @@ def main(args, pacu_main: 'Main'):
         delete_lambda(deploy_dir, env)
     else:
         principal = principal
-        s3_access_key: 'AWSKey' = pacu_main.get_aws_key_by_alias(args.s3_access_key)
+        print(args.s3_access_key)
+        s3_access_key: 'AWSKey' = pacu_main.get_aws_key_by_alias_from_db(args.s3_access_key)
         deploy_lambda(pacu_main, env, deploy_dir, bucket, principal, s3_access_key)
 
     region = get_region(bucket, pacu_main.get_regions('lambda'))
-    s3_notifications_sess = get_session_from_key_name(pacu_main, s3_notifications_setup_key, region)
+    s3_notifications_sess = get_aws_key_by_name(pacu_main, s3_notifications_setup_key, region)
 
     # No need to remove this on args.delete since we are deleting the lambda either way.
     if not args.delete:
@@ -242,11 +243,15 @@ def deploy_lambda(pacu: 'Main', env: dict, deploy_dir: Path, bucket: str, princi
     print = pacu.print
 
     print(f"Will deploy lambda to {env['AWS_DEFAULT_REGION']}")
+    print((Path(__file__).parent / 'cfn__resource_injection_lambda'))
+    print(deploy_dir)
     if not deploy_dir.exists():
-        shutil.copytree((Path(__file__).parent / 'cfn__resource_injection_lambda'), deploy_dir, dirs_exist_ok=True)
+        shutil.copytree((Path(__file__).parent / 'cfn__resource_injection_lambda'), deploy_dir, dirs_exist_ok=False)
 
     config_path = deploy_dir / '.chalice' / 'config.json'
     config = json.loads(config_path.read_text())
+    print(s3_key)
+    print(principal)
 
     config['stages']['dev']['environment_variables']['PRINCIPAL'] = principal
     config['stages']['dev']['environment_variables']['BUCKET'] = bucket
@@ -289,6 +294,19 @@ def get_session_from_key_name(pacu_main: 'Main', key_name: str, region: str = 'u
         aws_secret_access_key=key.secret_access_key,
         aws_session_token=key.session_token,
     )
+
+
+def get_aws_key_by_name(pacu_main: 'Main', key_name: str, region: str = 'us-east-1'):
+    key: 'AWSKey' = pacu_main.get_aws_key_by_alias_from_db(key_name)
+    if not key:
+        raise PacuException(f"Did not find the key {key_name} in pacu, make sure to set this with `set_keys` first.")
+
+    return boto3.Session(
+        region_name=region,
+        aws_access_key_id=key.access_key_id,
+        aws_secret_access_key=key.secret_access_key,
+        aws_session_token=key.session_token,
+    )    
 
 
 def put_bucket_notification(sess: 'boto3.Session', bucket: str, lambda_arn: str):
@@ -370,3 +388,4 @@ def remove_lambda_permission(sess: 'boto3.Session', lambda_name: str):
 
 def summary(data, pacu_main):
     return data
+


### PR DESCRIPTION
Currently for the module cfn__resource_injection takes two input

1. s3-access-key : Victims key
2. attacker-key: Attackers key

In the code we are checking if current session is victims key or not and throwing an error. Victims key and Attacker key cannot have same pacu session at same time, we should just check if victims key exists in pacu database and use that as needed.   Function `get_aws_key_by_alias_from_db` checks if give key alias exists in db or not. 

```
Pacu (attack:attack) > run cfn__resource_injection --attacker-key attack --s3-access-key victim 

```