### PR TITLE
Fix no loop break when enter for key alias

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -1294,6 +1294,8 @@ aws_secret_access_key = {}
             new_value = ""
             while (new_value.strip().lower() != 'c') and (len(new_value) < 2):
                 new_value = self.input('Key alias [{}]: '.format(session.key_alias))
+                if new_value == '':
+                    new_value = session.key_alias
         else:
             new_value = key_alias.strip()
             self.print('Key alias [{}]: {}'.format(session.key_alias, new_value), output='file')

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -1295,7 +1295,7 @@ aws_secret_access_key = {}
             while (new_value.strip().lower() != 'c') and (len(new_value) < 2):
                 new_value = self.input('Key alias [{}]: '.format(session.key_alias))
                 if new_value == '':
-                    new_value = session.key_alias
+                    new_value = str(session.key_alias)
         else:
             new_value = key_alias.strip()
             self.print('Key alias [{}]: {}'.format(session.key_alias, new_value), output='file')


### PR DESCRIPTION
Fixes a bug where the the loop when entering a key alias never breaks if the user just presses enter to keep the same value.