### PR TITLE
add jq command to parse collected data

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -5,6 +5,7 @@ import json
 import os
 import random
 import re
+import jq
 import shlex
 import subprocess
 import sys
@@ -90,6 +91,7 @@ def display_pacu_help():
         data                                Display all data that is stored in this session. Only fields
                                               with values will be displayed
         data <service> [<sub-service>]      Display all data for a specified service in this session
+        jq <query> <service> [<sub-service>] Run a jq statement on the specified service's data
         services                            Display a list of services that have collected data in the
                                               current session to use with the "data" command
         regions                             Display a list of all valid AWS regions
@@ -667,6 +669,8 @@ class Main:
             return
         elif command[0] == 'data':
             self.parse_data_command(command)
+        elif command[0] == 'jq':
+            self.parse_jq_command(command)
         elif command[0] == 'sessions' or command[0] == 'list_sessions':
             self.list_sessions()
         elif command[0] == 'swap_session':
@@ -809,6 +813,22 @@ class Main:
             return '  No data found.'
         else:
             return json.dumps(service_data[name], indent=2, sort_keys=True, default=str)
+
+    def parse_jq_command(self, command):
+        session = self.get_active_session()
+        data_command = ["data"] + command[2:]
+        data = self._parse_data_command(data_command, session)
+        try:
+            data = json.loads(data)
+        except json.decoder.JSONDecodeError:
+            print(data)
+            return
+        try:
+            jq_output = jq.all(command[1], data)
+        except ValueError as e:
+            print(e)
+            return
+        print(json.dumps(jq_output, indent=2, sort_keys=True, default=str))
 
     def parse_set_regions_command(self, command):
         session = self.get_active_session()

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -5,7 +5,6 @@ import json
 import os
 import random
 import re
-import jq
 import shlex
 import subprocess
 import sys
@@ -21,6 +20,7 @@ from pacu.core.lib import session_dir
 from datetime import datetime
 
 try:
+    import jq  # type: ignore
     import requests
     import boto3
     import botocore

--- a/poetry.lock
+++ b/poetry.lock
@@ -610,6 +610,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "jq"
+version = "1.4.1"
+description = "jq is a lightweight and flexible JSON processor."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "markupsafe"
 version = "2.0.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1114,7 +1122,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "17b7ea8d26e09b5d8e6afdb8bd5f7db615b7713819572912fc7cc93c8b53679f"
+content-hash = "821c9ccbc032654a10efb725fc376d1322d5a8cc1bd21668015c419b06bfc06f"
 
 [metadata.files]
 ansicon = [
@@ -1280,6 +1288,63 @@ jinxed = [
 jmespath = [
     {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
+]
+jq = [
+    {file = "jq-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1708cad6ee0f173ce38c6ebfc81b98a545b35387ae6471c8d7f9f3a02ffb723e"},
+    {file = "jq-1.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c94e70e5f0798d87018cd4a58175f4eed2afa08727389a0f3f246bf7e7b98d1e"},
+    {file = "jq-1.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddc2c6b55c5461c6f155c4b717927bdd29a83a6356250c4e6016297bcea80498"},
+    {file = "jq-1.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2e71f5a921542efbea12386ca9d91ea1aeb6bd393681073e4a47a720613715f"},
+    {file = "jq-1.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b2bf666002d23ee8cf9e619d2d1e46d86a089e028367665386b9d67d22b31ceb"},
+    {file = "jq-1.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e33954fe47e61a533556d38e045ddd7b3fa8a8186a70981462a207ed22594d83"},
+    {file = "jq-1.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:07905774df7706588014ca49789548328e8f66738b004089b3f0c42f7f389405"},
+    {file = "jq-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:959b2e677e56dc31c8572c0852ad26d3b351a8a458ca72c96f8cedfcde49419f"},
+    {file = "jq-1.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e74ab69d39b171f1625fa666baa8f9a1ff49e7295047082bcb537fcc2d359dfe"},
+    {file = "jq-1.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:103412f7f35175eb9a1005e4e2067b363dfcdb413d02fa962ddf288b2b16cc54"},
+    {file = "jq-1.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f70d5e0c6445cc58f720de2ab44c156c69ce6d898c4d4ad04f07815868e31ed"},
+    {file = "jq-1.4.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:db980118c02321c56b6e0ddf817ad1cbbd8b6c90f4637bdebb695e84ee41a296"},
+    {file = "jq-1.4.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:9b295a51a9ea7e324aa7ad2ce2cca3d51d7492a525cd7a59773666a07b1cc0f7"},
+    {file = "jq-1.4.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:82b44474641dcdb07b43267d17f77914595768e9464b31de114e6c229a16ac6e"},
+    {file = "jq-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:582c40d7e212e310cf1ed0fddc4590853b64a5e09aed1f740613765c83cff072"},
+    {file = "jq-1.4.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75f4269f709f746bf3d52df2c4ebc316d4985e0db97b7c1a293f02202befcdcb"},
+    {file = "jq-1.4.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a060fd3172f8833828cb26151ea2f6c0f99f0191109ad580baee7befbdd6e65"},
+    {file = "jq-1.4.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bfd61be72ad1e35622a7525e55615954ccfbe6ccadabd7f964e879bb4a53ad6"},
+    {file = "jq-1.4.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:4364c45113407f1316a99bd7a8661aa9304eb3578c80b201917aa8568fa40ee1"},
+    {file = "jq-1.4.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:0a8c37073a335596c645f0260fd3ea7b6141c2fb0115a0b8082252b0169f70c8"},
+    {file = "jq-1.4.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:96e5160f77498389e388e7ba3cd1771abc386b52788c82dee897c95bc87efe6f"},
+    {file = "jq-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fac91eb91bec60dee28e2325f863c43d12ffc904ee72248522c6d0157ae98a54"},
+    {file = "jq-1.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:581e771e7c4aad728f9696ce6faee0f3d535cb0c845a49ac20188d8c7918e19d"},
+    {file = "jq-1.4.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31b6526533cbc298ae0c0084d22452fbd3b4600ace488dc961ecf9a1dcb51a83"},
+    {file = "jq-1.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1830a9fd394673758010e41e8d0e00be7126b0ea9f3ede017a555c0c805435bc"},
+    {file = "jq-1.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6b11e71b4d00928898f494d8e2945b80aab0447a4f2e7fb4603ac32cccc4e28e"},
+    {file = "jq-1.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3e4dd3ba62e284479528a5a00084c2923a08de7cb7fe154036a345190ed5bc24"},
+    {file = "jq-1.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7dfa6ff7424339ed361d911a13635e7c2f888e18e42920a8603e8806d85fdfdc"},
+    {file = "jq-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:419f8d28e737b96476ac9ba66e000e4d93e54dd8003f1374269315086b98d822"},
+    {file = "jq-1.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de27a580663825b493b061682b59704f29a748011f2e5bc4701b34f8f17ed405"},
+    {file = "jq-1.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebfec7c54b3252ec59663a21885e97d49b1dd455d8db0223bb77073b9b248fc3"},
+    {file = "jq-1.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:56a21666412dd1a6b8306475d0ec6e1eba7965100b3dfd6ecf1eb537aabec513"},
+    {file = "jq-1.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f97b1e2582d64b65069f2d8b5e08f94f1d0998233c98c0d6edcf0a610262cd3a"},
+    {file = "jq-1.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:33b5fcbf32c24557dd638e59b919f2ecfa98e65cf4b96f63c327ed10ea24495d"},
+    {file = "jq-1.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a16fb7e2e0942b4661a8d210e9ac3292b5f021abbcddbbcb6b783f9eb5d7a6cb"},
+    {file = "jq-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4c4d6b9f30556d5f17552ac2ef8563872a2c0271cc7c8789c87546270135ae15"},
+    {file = "jq-1.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f82346544116503cbdfd56ac5e90f837c2b96d69b64a3444df2770156dc8d64"},
+    {file = "jq-1.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1799792f34ca8441fb1c4b3cf05c644ef2a4b28ad07bae65b1c7cde8f26721b4"},
+    {file = "jq-1.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2403bfcaedbe860ffaa3258b65ad3dcf72d2d97c59acf6f8fd5f663a1b0a183a"},
+    {file = "jq-1.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c59ebcd4f0bb99d5d69085905c80d8ebf95df522750d95e33985121daa4e1de4"},
+    {file = "jq-1.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:aa7fadeca796eb385b93217fb65ac2c54150ac3fcea2722c0c76390f0d6b2681"},
+    {file = "jq-1.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:11fb7e41c4931127cfe5c53b1eb812d797ed7d47a8ab22f6cb294cf470d5038b"},
+    {file = "jq-1.4.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fc8f67f7b8140e51bd291686055d63f62b60fa3bea861265309f54fd74f5517d"},
+    {file = "jq-1.4.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30ce02d9c01ffea7c92b4ec006b114c4047816f15016173dced3fc046760b854"},
+    {file = "jq-1.4.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbbfdfbb0bc2d615edfa8213720423885c022a827ea3c8e8593bce98b6086c99"},
+    {file = "jq-1.4.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9053a8e9f3636d367e8bb0841a62d839f2116e6965096d95c38a8f9da57eed66"},
+    {file = "jq-1.4.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3ecdffb3abc9f1611465b761eebcdb3008ae57946a86a99e76bc6b09fe611f29"},
+    {file = "jq-1.4.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5f0688f98dedb49a5c680b961a4f453fe84b34795aa3203eec77f306fa823d5"},
+    {file = "jq-1.4.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:342f901a9330d12d2c2baf17684b77ae198fade920d061bb844d1b3733097792"},
+    {file = "jq-1.4.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:761713740c19dd0e0da8b6eaea7f588df2af64d8e32d1157a3a05028b0fec2b3"},
+    {file = "jq-1.4.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:6343d929e48ba4d75febcd987752931dc7a70e1b2f6f17b74baf3d5179dfb6a5"},
+    {file = "jq-1.4.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ec82f8925f7a88547cd302f2b479c81af17468dbd3473d688c3714a264f90c0"},
+    {file = "jq-1.4.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95edc023b97d1a44fd1e8243119a3532bc0e7d121dfdf2722471ec36763b85aa"},
+    {file = "jq-1.4.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc4dd73782c039c66b25fc103b07fd46bac5d2f5a62dba29b45ae97ca88ba988"},
+    {file = "jq-1.4.1.tar.gz", hash = "sha256:52284ee3cb51670e6f537b0ec813654c064c1c0705bd910097ea0fe17313516d"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ typing-extensions = "^3.7.4.3"
 dsnap = "^1.0.0"
 chalice = "^1.23.0"
 policyuniverse = "^1.5.0.20220613"
+jq = "^1.4.1"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.1"


### PR DESCRIPTION
This adds a `jq` command to Pacu to help parsing collected data output.
```
run ec2__enum
jq '.Instances[].InstanceId' ec2
```
This partially handles #181 it makes it easier to parse and filter the data, although does not really make is searchable.