### PR TITLE
fix #329 key error issue with iam__privesc_scan

### DIFF
--- a/pacu/modules/iam__privesc_scan/main.py
+++ b/pacu/modules/iam__privesc_scan/main.py
@@ -1231,7 +1231,7 @@ def main(args, pacu_main: "Main"):
                 if perm in target["Permissions"][effect]:
                     checked_perms[effect][perm] = target["Permissions"][effect][perm]
                 else:
-                    for target_perm in target["Permissions"][effect].keys():
+                    for target_perm in target["Permissions"][effect]:
                         if "*" in target_perm:
                             pattern = re.compile(target_perm.replace("*", ".*"))
                             if pattern.search(perm) is not None:


### PR DESCRIPTION
fix #329
unconfirmed permission do not have keys it appears, they are just a list of permissions.

The bug was reproduced by running:

```
iam__bruteforce_permissions
iam__privesc_scan
```