### PR TITLE
Make pacu version expand in workflow for docker version

### DIFF
--- a/.github/workflows/python-deploy-pypi.yml
+++ b/.github/workflows/python-deploy-pypi.yml
@@ -36,8 +36,8 @@ jobs:
       run: |
         poetry version ${{ github.event.inputs.SemVer_level }}
         ver="$(poetry version -s)"
-        sed -i 's/pacu.version=".*"/pacu.version="${ver}"/' Dockerfile
-        sed -i 's/pacu.version=".*"/pacu.version="${ver}"/' Dockerfile.dev
+        sed -i "s/pacu.version=\".*\"/pacu.version=\"$ver\"/" Dockerfile
+        sed -i "s/pacu.version=\".*\"/pacu.version=\"$ver\"/" Dockerfile.dev
     - name: Commit and push version changes
       run: |
         ver="$(poetry version -s)"


### PR DESCRIPTION
the pacu version is not expanded into the docker files when workflow runs, this should fix it.