### PR TITLE
Added ed25519 private key pattern on regexs.json for secret finder functionality

### DIFF
--- a/pacu/core/secretfinder/regexs.json
+++ b/pacu/core/secretfinder/regexs.json
@@ -23,6 +23,7 @@
     "RSA private key": "-----BEGIN RSA PRIVATE KEY-----",
     "SSH (DSA) private key": "-----BEGIN DSA PRIVATE KEY-----",
     "SSH (EC) private key": "-----BEGIN EC PRIVATE KEY-----",
+    "SSH (ed25519) private key": "-----BEGIN OPENSSH PRIVATE KEY-----"
     "PGP private key block": "-----BEGIN PGP PRIVATE KEY BLOCK-----",
     "Twilio API Key": "SK[0-9a-fA-F]{32}",
     "Twitter Access Token": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*[1-9][0-9]+-[0-9a-zA-Z]{40}",


### PR DESCRIPTION
as this algorithm is getting more popular and being suggested (eg: by github) https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key

Issue #396 