### PR TITLE
Feature/update cognito  attack

### DIFF
--- a/pacu/modules/cognito__attack/main.py
+++ b/pacu/modules/cognito__attack/main.py
@@ -975,11 +975,7 @@ def parse_user_attributes(user_attributes: str) -> List[Dict[str, str]]:
 
 
 def sign_up(client, email, client_id, username, password, user_attributes=None):
-    if user_attributes is None:
-        user_attributes = []
-    print(user_attributes)
-    print(email)
-
+    user_attributes = user_attributes or []
     email_exists = any(attribute["Name"] == "email" for attribute in user_attributes)
 
     if email and not email_exists:
@@ -990,7 +986,7 @@ def sign_up(client, email, client_id, username, password, user_attributes=None):
             ClientId=client_id,
             Username=username,
             Password=password,
-            UserAttributes=user_attributes or [],
+            UserAttributes=user_attributes,
         )
         print(f"Successfully signed up user {username}.")
         return True
@@ -1006,19 +1002,8 @@ def sign_up(client, email, client_id, username, password, user_attributes=None):
             )
             if parameter:
                 attribute_name = parameter.group(1)
-                prompt = f"Enter value for {attribute_name}: "
-                param_value = input(prompt)
+                param_value = input(f"Enter value for {attribute_name}: ")
                 user_attributes.append({"Name": attribute_name, "Value": param_value})
-                return sign_up(
-                    client, email, client_id, username, password, user_attributes
-                )
-            else:
-                print(f"Required attribute: {str(e)}")
-                param_name = input("Please enter the name of the required attribute: ")
-                param_value = input(
-                    "Please enter the value of the required attribute: "
-                )
-                user_attributes.append({"Name": param_name, "Value": param_value})
                 return sign_up(
                     client, email, client_id, username, password, user_attributes
                 )
@@ -1026,13 +1011,14 @@ def sign_up(client, email, client_id, username, password, user_attributes=None):
             print(f"Invalid parameter: {str(e)}")
             param_name = input("Please enter the name of the invalid parameter: ")
             param_value = input("Please enter the value of the invalid parameter: ")
-            if param_name.lower() == "username":
+            if param_name.lower() in ["username", "password"]:
                 return sign_up(
-                    client, email, client_id, param_value, password, user_attributes
-                )
-            if param_name.lower() == "password":
-                return sign_up(
-                    client, email, client_id, username, param_value, user_attributes
+                    client,
+                    email,
+                    client_id,
+                    param_name.lower() == "username" and param_value or username,
+                    param_name.lower() == "password" and param_value or password,
+                    user_attributes,
                 )
             user_attributes.append({"Name": param_name, "Value": param_value})
             return sign_up(


### PR DESCRIPTION
## Summary

I've encountered an issue in the `cognito__attack` module of the Pacu framework — when attempting to exploit the `vulnerable_cognito` user pool, the script requests the `familyName` and `givenName` attributes repeatedly without progressing.

Upon running the `cognito__attack`, the module falls into a loop, asking for the `name.familyName` and `name.givenName` even after supplying the correct values. Additionally, it gives an error saying "Username should be an email," suggesting a deeper issue with how user attributes are handled.

It turns out the expected attribute keys should be `family_name` and `given_name`, not `familyName` and `givenName`. 
---

Example code:
```bash
run cognito__attack --username vulnerablecognito@10minmail.de --email vulnerablecognito@10minmail.de --user_pool_clients 52077oo7e3h4fmklumdt4gn0ou@us-east-1_GUKqIkgg2
  Running module cognito__attack...
[cognito__attack] Attempting to sign up user in user pool client 52077oo7e3h4fmklumdt4gn0ou in region us-east-1 . . . 
[]
vulnerablecognito@10minmail.de
User attributes specified.
An error occurred (InvalidParameterException) when calling the SignUp operation: Attributes did not conform to the schema: name.givenName: The attribute name.givenName is required, name.familyName: The attribute name.familyName is required
Invalid parameter: An error occurred (InvalidParameterException) when calling the SignUp operation: Attributes did not conform to the schema: name.givenName: The attribute name.givenName is required, name.familyName: The attribute name.familyName is required
Please enter the name of the invalid parameter: name.familyName
Please enter the value of the invalid parameter: Doe
[{'Name': 'email', 'Value': 'vulnerablecognito@10minmail.de'}]
vulnerablecognito@10minmail.de
User attributes specified.
An error occurred (InvalidParameterException) when calling the SignUp operation: Username should be an email.
Invalid parameter: An error occurred (InvalidParameterException) when calling the SignUp operation: Username should be an email.
Please enter the name of the invalid parameter: name.givenName
Please enter the value of the invalid parameter: John
[{'Name': 'email', 'Value': 'vulnerablecognito@10minmail.de'}, {'Name': 'email', 'Value': 'vulnerablecognito@10minmail.de'}]
vulnerablecognito@10minmail.de
User attributes specified.
An error occurred (InvalidParameterException) when calling the SignUp operation: Username should be an email.
Invalid parameter: An error occurred (InvalidParameterException) when calling the SignUp operation: Username should be an email.
Please enter the name of the invalid parameter: username
```

## Changes

- added user_attributes parameter and logic
- updated logic to handle the described issue
- flake8 updates

## Additional Notes

I have not seen any test that I could provide so I didn't. All of my manual testing was OK, but this needs to be tested by somebody else as well. 
