### PR TITLE
Fix an error in ebs__download_snapshots

### DIFF
--- a/pacu/modules/ebs__download_snapshots/main.py
+++ b/pacu/modules/ebs__download_snapshots/main.py
@@ -2,6 +2,7 @@
 """Module for ebs_snapshot_explorer"""
 import argparse
 import sys
+import os
 from typing import List
 from typing_extensions import TypedDict
 
@@ -79,6 +80,9 @@ def main(args, pacu: Main):
 
     try:
         out_dir = downloads_dir()/'ebs/snapshots'
+        # Check if the directory exists, create if not
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
         snap = snapshot.LocalSnapshot(str(out_dir), snapshot_id, pacu.get_boto_session(region=region), pacu.get_botocore_conf())
     except UserWarning as e:
         print(*e.args)


### PR DESCRIPTION
When running ```ebs__download_snapshots``` the user will encounter an error because the output directory is not created yet. This fix will check if the directory exists and if not, create the directory allowing the command to succeed. 

Current error message:
```
    <class 'FileNotFoundError'>: [Errno 2] No such file or directory: '/home/[user]/.local/share/pacu/[aws-user]/downloads/ebs/snapshots/snap-0c241b0d00d234853.img'```