### PR TITLE
Validate target-instances for systemsmanager__rce_ec2

### DIFF
--- a/pacu/modules/systemsmanager__rce_ec2/main.py
+++ b/pacu/modules/systemsmanager__rce_ec2/main.py
@@ -258,7 +258,11 @@ def main(args, pacu_main):
         regions = []
         instances_id_regions = args.target_instances.split(',')
         for instance_id_region in instances_id_regions:
-            instance_id, instance_region = instance_id_region.split('@')
+            try:
+                instance_id, instance_region = instance_id_region.split('@')
+            except ValueError as error:
+                print('  Unable to validate provided target_instances. Ensure they match the format instance-id@region. Error: {}\n'.format(str(error)))
+                return
             regions.append(instance_region)
             client = pacu_main.get_boto3_client('ec2', instance_region)
             instance = client.describe_instances(InstanceIds=[instance_id])["Reservations"][0]["Instances"][0]


### PR DESCRIPTION
When providing an invalidly formatted `target-instances`, `systemsmanager__rce_ec2` crashes with a python error instead of providing useful feedback to the user. This PR fixes that to ensure parsing of the values returns an expected size (value).

## Before PR

```
Pacu (example:example) > run systemsmanager__rce_ec2 --target-instances "i-11a11a1a111111a11" --command "whoami" --ip-name "arn:aws:iam::1111111111:example"

  Running module systemsmanager__rce_ec2...

[2024-05-17 17:23:47] Pacu encountered an error while running the previous command. Check /home/user/.local/share/pacu/example/error_log.txt for technical details. [LOG LEVEL: MINIMAL]

    <class 'ValueError'>: not enough values to unpack (expected 2, got 1)
```

## After PR

```
Pacu (example:example) > run systemsmanager__rce_ec2 --target-instances "i-11a11a1a111111a11" --command "whoami" --ip-name "arn:aws:iam::1111111111:example"

[systemsmanager__rce_ec2]   Unable to validate provided target_instances. Ensure they match the format instance-id@region. Error: not enough values to unpack (expected 2, got 1)
```
