### PR TITLE
 Add error handling to get_policy in systemsmanager__rce_ec2

### DIFF
--- a/pacu/modules/systemsmanager__rce_ec2/main.py
+++ b/pacu/modules/systemsmanager__rce_ec2/main.py
@@ -39,7 +39,7 @@ parser.add_argument('--target-os', required=False, default='All', help='This arg
 parser.add_argument('--all-instances', required=False, default=False, action='store_true', help='Skip vulnerable operating system check and just target every instance')
 parser.add_argument('--target-instances', required=False, default=None, help='A comma-separated list of instances and regions to set as the attack targets in the format of instance-id@region,instance2-id@region...')
 parser.add_argument('--replace', required=False, default=False, action='store_true', help='For EC2 instances that already have an instance profile attached to them, this argument will replace those with the Systems Manager instance profile. WARNING: This can cause bad things to happen! You never know what negative side effects this may have on a server without further inspection, because you do not know what permissions you are removing/replacing that the instance already had')
-parser.add_argument('--ip-name', required=False, default=None, help='The name of an existing instance profile with an "EC2 Role for Simple Systems Manager" attached to it. This will skip the automatic role/instance profile enumeration and the searching for a Systems Manager role/instance profile')
+parser.add_argument('--ip-name', required=False, default=None, help='The name of an existing instance profile with an "EC2 Role for Simple Systems Manager" attached to it. This will skip the automatic role/instance profile enumeration and the searching for a Systems Manager role/instance profile. Example: "arn:aws:iam::1111111111111:user/example"')
 
 
 def main(args, pacu_main):
@@ -140,9 +140,13 @@ def main(args, pacu_main):
         # Begin Systems Manager role finder/creator
         client = pacu_main.get_boto3_client('iam')
 
-        ssm_policy = client.get_policy(
-            PolicyArn='arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
-        )['Policy']
+        try:
+            ssm_policy = client.get_policy(
+                PolicyArn='arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+            )['Policy']
+        except ClientError as error:
+            print('  Unable to retrieve policy (arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM). Try specifying the ip-name manually. Error: {}\n'.format(str(error)))
+            return
 
         if ssm_policy['AttachmentCount'] > 0:
             if fetch_data(['IAM', 'Roles'], module_info['prerequisite_modules'][1], '--roles') is False:


### PR DESCRIPTION
Gracefully handle an access denied error when `get_policy` fails (AccessDenied), and give the user a suggestion on how to fix it.  I left the original bubbled up error message in there as it gives additional context that could help a user debug, but felt the suggestion of manually setting an `ip-name` is a good tip (it got the module to run for me).

## Pre

```
Pacu (example:example) > run systemsmanager__rce_ec2 --target-instances "i-11a11a1a111111a11" --command "whoami" --ip-name "arn:aws:iam::1111111111:example"
  Running module systemsmanager__rce_ec2...

[2024-05-17 17:26:06] Pacu encountered an error while running the previous command. Check /home/cb7192/.local/share/pacu/thomas/error_log.txt for technical details. [LOG LEVEL: MINIMAL]

    <class 'botocore.exceptions.ClientError'>: An error occurred (AccessDenied) when calling the GetPolicy operation: User: arn:aws:iam::999143725571:user/tomas_sysadmin is not authorized to perform: iam:GetPolicy on resource: policy arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM because no identity-based policy allows the iam:GetPolicy action
```

## Post

```
Pacu (example:example) > run systemsmanager__rce_ec2 --target-instances "i-11a11a1a111111a11" --command "whoami" --ip-name "arn:aws:iam::1111111111:example"
  Running module systemsmanager__rce_ec2...

[systemsmanager__rce_ec2]   Unable to retrieve policy (arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM). Try specifying the ip-name manually. Error: An error occurred (AccessDenied) when calling the GetPolicy operation: User: arn:aws:iam::1111111111:example is not authorized to perform: iam:GetPolicy on resource: policy arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM because no identity-based policy allows the iam:GetPolicy action
```