### PR TITLE
Enhance iam__enum_permissions w/ unconfirmed and counts

### DIFF
--- a/pacu/modules/iam__enum_permissions/main.py
+++ b/pacu/modules/iam__enum_permissions/main.py
@@ -559,7 +559,7 @@ def summary(data, pacu_main):
                                                                                   count_max_len=count_max_len)
     else:
         out += "{:>{count_max_len}} Unconfirmed permissions for {} user(s).\n".format(data["users_unconfirmed_perm_count"],
-                                                                                  data["single_user"],
+                                                                                  data["users_unconfirmed"],
                                                                                   count_max_len=count_max_len)
 
     if data["roles_unconfirmed"] == 1:

--- a/pacu/modules/iam__enum_permissions/main.py
+++ b/pacu/modules/iam__enum_permissions/main.py
@@ -91,7 +91,7 @@ def main(args, pacu_main: "Main"):
     summary_data = {"users_confirmed": 0, "roles_confirmed": 0,
                    "users_unconfirmed": 0, "roles_unconfirmed": 0,
                    "users_confirmed_perm_count": 0, "roles_confirmed_perm_count": 0,
-                   "users_unconfirmed_perm_count": 0, "roles_unconfirmed_perm_count": 0}}
+                   "users_unconfirmed_perm_count": 0, "roles_unconfirmed_perm_count": 0}
 
     users = []
     roles = []
@@ -529,35 +529,47 @@ def summary(data, pacu_main):
     if not data:
         return "  Unable to find users/roles to enumerate permissions\n"
 
+    count_max_len = 2 + max(data["users_confirmed_perm_count"],
+                            data["roles_confirmed_perm_count"],
+                            data["users_unconfirmed_perm_count"],
+                            data["roles_unconfirmed_perm_count"])
+
     # Create Confirmed listings
     if data.get("single_user") and data["users_confirmed"] == 1:
-            out += "  Confirmed permissions for user: {}.\n".format(data["single_user"])
+        out += "{:>{count_max_len}} Confirmed permissions for user: {}.\n".format(data["users_confirmed_perm_count"],
+                                                                                  data["single_user"],
+                                                                                  count_max_len=count_max_len)
     else:
-        out += "  Confirmed permissions for {} user(s).\n".format(
-            data["users_confirmed"]
-        )
+        out += "{:>{count_max_len}} Confirmed permissions for {} user(s).\n".format(data["users_confirmed_perm_count"],
+                                                                                    data["users_confirmed"],
+                                                                                    count_max_len=count_max_len)
 
     if data["roles_confirmed"] == 1:
-        out += "  Confirmed permissions for role: {}.\n".format(data["single_role"])
+        out += "{:>{count_max_len}} Confirmed permissions for role: {}.\n".format(data["roles_confirmed_perm_count"],
+                                                                                  data["single_role"],
+                                                                                  count_max_len=count_max_len)
     else:
-        out += "  Confirmed permissions for {} role(s).\n".format(
-            data["roles_confirmed"]
-        )
-
+        out += "{:>{count_max_len}} Confirmed permissions for {} role(s).\n".format(data["roles_confirmed_perm_count"],
+                                                                                    data["roles_confirmed"],
+                                                                                    count_max_len=count_max_len)
     # Create Unconfirmed listings
     if data.get("single_user") and data["users_unconfirmed"] == 1:
-            out += "  Unconfirmed permissions for user: {}.\n".format(data["single_user"])
+            out += "{:>{count_max_len}} Unconfirmed permissions for user: {}.\n".format(data["users_unconfirmed_perm_count"],
+                                                                                  data["single_user"],
+                                                                                  count_max_len=count_max_len)
     else:
-        out += "  Unconfirmed permissions for {} user(s).\n".format(
-            data["users_unconfirmed"]
-        )
+        out += "{:>{count_max_len}} Unconfirmed permissions for {} user(s).\n".format(data["users_unconfirmed_perm_count"],
+                                                                                  data["single_user"],
+                                                                                  count_max_len=count_max_len)
 
     if data["roles_unconfirmed"] == 1:
-        out += "  Unconfirmed permissions for role: {}.\n".format(data["single_role"])
+        out += "{:>{count_max_len}} Unconfirmed permissions for role: {}.\n".format(data["roles_unconfirmed_perm_count"],
+                                                                                    data["single_role"],
+                                                                                    count_max_len=count_max_len)
     else:
-        out += "  Unconfirmed permissions for {} role(s).\n".format(
-            data["roles_unconfirmed"]
-        )
+        out += "{:>{count_max_len}} Unconfirmed permissions for {} role(s).\n".format(data["roles_unconfirmed_perm_count"],
+                                                                                      data["roles_unconfirmed"],
+                                                                                      count_max_len=count_max_len)
     return out
 
 

--- a/pacu/modules/iam__enum_permissions/main.py
+++ b/pacu/modules/iam__enum_permissions/main.py
@@ -529,10 +529,10 @@ def summary(data, pacu_main):
     if not data:
         return "  Unable to find users/roles to enumerate permissions\n"
 
-    count_max_len = 2 + max(data["users_confirmed_perm_count"],
-                            data["roles_confirmed_perm_count"],
-                            data["users_unconfirmed_perm_count"],
-                            data["roles_unconfirmed_perm_count"])
+    count_max_len = 2 + max(len(str(data["users_confirmed_perm_count"])),
+                            len(str(data["roles_confirmed_perm_count"])),
+                            len(str(data["users_unconfirmed_perm_count"])),
+                            len(str(data["roles_unconfirmed_perm_count"])))
 
     # Create Confirmed listings
     if data.get("single_user") and data["users_confirmed"] == 1:

--- a/pacu/modules/iam__enum_permissions/main.py
+++ b/pacu/modules/iam__enum_permissions/main.py
@@ -88,7 +88,10 @@ def main(args, pacu_main: "Main"):
     fetch_data = pacu_main.fetch_data
     # End don't modify
 
-    summary_data = {"users_confirmed": 0, "roles_confirmed": 0}
+    summary_data = {"users_confirmed": 0, "roles_confirmed": 0,
+                   "users_unconfirmed": 0, "roles_unconfirmed": 0,
+                   "users_confirmed_perm_count": 0, "roles_confirmed_perm_count": 0,
+                   "users_unconfirmed_perm_count": 0, "roles_unconfirmed_perm_count": 0}}
 
     users = []
     roles = []
@@ -285,6 +288,10 @@ def main(args, pacu_main: "Main"):
                 role = parse_attached_policies(client, attached_policies, role)
                 if role["PermissionsConfirmed"]:
                     summary_data["roles_confirmed"] += 1
+                    summary_data["roles_confirmed_perm_count"] += len(role["Permissions"]["Allow"]) + len(role["Permissions"]["Deny"])
+                else:
+                    summary_data["roles_unconfirmed"] += 1
+                    summary_data["roles_unconfirmed_perm_count"] += len(role["Permissions"]["Allow"]) + len(role["Permissions"]["Deny"])
 
                 if args.role_name is None and args.all_roles is False:
                     print("    Confirmed permissions for {}".format(role["RoleName"]))
@@ -476,6 +483,10 @@ def main(args, pacu_main: "Main"):
                 user = parse_attached_policies(client, attached_policies, user)
                 if user["PermissionsConfirmed"]:
                     summary_data["users_confirmed"] += 1
+                    summary_data["users_confirmed_perm_count"] += len(user["Permissions"]["Allow"]) + len(user["Permissions"]["Deny"])
+                else:
+                    summary_data["users_unconfirmed"] += 1
+                    summary_data["users_unconfirmed_perm_count"] += len(user["Permissions"]["Allow"]) + len(user["Permissions"]["Deny"])
 
                 if args.user_name is None and args.all_users is False:
                     print("    Confirmed Permissions for {}".format(user["UserName"]))
@@ -513,11 +524,14 @@ def main(args, pacu_main: "Main"):
 
 
 def summary(data, pacu_main):
+    """Generate module summary text"""
     out = ""
     if not data:
         return "  Unable to find users/roles to enumerate permissions\n"
-    if data["users_confirmed"] == 1 and data.get("single_user"):
-        out += "  Confirmed permissions for user: {}.\n".format(data["single_user"])
+
+    # Create Confirmed listings
+    if data.get("single_user") and data["users_confirmed"] == 1:
+            out += "  Confirmed permissions for user: {}.\n".format(data["single_user"])
     else:
         out += "  Confirmed permissions for {} user(s).\n".format(
             data["users_confirmed"]
@@ -528,6 +542,21 @@ def summary(data, pacu_main):
     else:
         out += "  Confirmed permissions for {} role(s).\n".format(
             data["roles_confirmed"]
+        )
+
+    # Create Unconfirmed listings
+    if data.get("single_user") and data["users_unconfirmed"] == 1:
+            out += "  Unconfirmed permissions for user: {}.\n".format(data["single_user"])
+    else:
+        out += "  Unconfirmed permissions for {} user(s).\n".format(
+            data["users_unconfirmed"]
+        )
+
+    if data["roles_unconfirmed"] == 1:
+        out += "  Unconfirmed permissions for role: {}.\n".format(data["single_role"])
+    else:
+        out += "  Unconfirmed permissions for {} role(s).\n".format(
+            data["roles_unconfirmed"]
         )
     return out
 


### PR DESCRIPTION
This PR modifies `iam__enum_permissions` to display unconfirmed permissions, and counts of each.

## Pre

To start, we have a new user and key entered in to the db.
![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/e0339139-29f8-4586-9d3f-7fbde4223daa)
When running `iam__enum_permissions` for this (limited) user, we get back the following output.
![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/4458e34f-047c-4f13-9f58-25f18f069711)
When looking at this output, it looks like the module failed. We have a `FAILURE`, a `FAILURE`, and while it says 'confirmed permissions for ...', nothing is listed like a user would expect, so I assume no permissions were found BUT the query didn't fail.  We move on down to the summary, and we see 0 and 0. So we must not have been able to enumerate.
However, we run a `whoami` and we see we *did* get permissions:
![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/40e29a8f-fe2c-41f6-93ac-731045dc739d)

The problem is that these are **unconfirmed** permissions.  However, they were found so the user should be notified of something.

## Post

We now keep track of how many unconfirmed items were present, and a count of the actual permissions. This allows us to give the user better output so they know data was found, which matches what they'll see in `whoami`.

![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/9618ad86-2ab9-4028-ade8-a8cb0f0acf2c)
