### PR TITLE
Fix module list generation for autocomplete

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -1587,7 +1587,7 @@ aws_secret_access_key = {}
                 category_path = os.path.realpath(root)
 
                 # Skip any directories inside module directories.
-                if os.path.dirname(category_path) != modules_directory_path:
+                if os.path.dirname(category_path) == modules_directory_path:
                     continue
                 # Skip the root directory.
                 elif modules_directory_path == category_path:
@@ -1621,7 +1621,7 @@ aws_secret_access_key = {}
                     if len(line) == 1 and (line[0] == 'help'):
                         return [c + ' ' for c in MODULES + self.COMMANDS][state]
 
-                    if len(line) == 1 and (line[0] == 'exec' or line[0] == 'run'):
+                    if len(line) == 1 and (line[0] in ['exec', 'run']):
                         return [c + ' ' for c in MODULES][state]
 
                     # account for last argument ending in a space


### PR DESCRIPTION
Fixes #423 

Fixes a bug which prevented the autocomplete feature from knowing about modules.

When generating the list of modules, an incorrect if statement was making no modules appear.  This corrects that logic, and the list now generates.
After the fix, typing `run` command now correctly generates a list of possible module candidates.
![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/891217cc-521e-4cb1-b446-e2c0ff815667)
