### PR TITLE
change enum__secrets to secrets__enum

### DIFF
--- a/pacu/modules/secrets__enum/main.py
+++ b/pacu/modules/secrets__enum/main.py
@@ -7,7 +7,7 @@ from pacu.core.lib import strip_lines, save
 from pacu import Main
 
 module_info = {
-    'name': 'enum__secrets',
+    'name': 'secrets__enum',
     'author': 'Nick Spagnola From RSL',
     'category': 'ENUM',
     'one_liner': 'Enumerates and dumps secrets from AWS Secrets Manager and AWS parameter store',


### PR DESCRIPTION
All modules seem to use the naming scheme of `component__action`. However, `enum__secrets` seems to be the opposite. This PR changes the name to conform to the rest of the framework.