### PR TITLE
fix iam__decode_accesskey_id category

### DIFF
--- a/pacu/modules/iam__decode_accesskey_id/main.py
+++ b/pacu/modules/iam__decode_accesskey_id/main.py
@@ -5,7 +5,7 @@ from pacu.utils import decode_accesskey_id
 module_info = {
     'name': 'iam__decode_accesskey_id',
     'author': 'Rhino Security Labs',
-    'category': 'enum',
+    'category': 'ENUM',
     'one_liner': 'This module decodes an access key ID to get the AWS account ID. Based on: https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489',
     'description': 'This module decodes an access key ID to get the AWS account ID without making and AWS API calls. Based on: https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489',
     'services': ['IAM'],


### PR DESCRIPTION
categories are always UPPERCASE. `iam__decode_accesskey_id` seems to be a one off, which is causing it to get its own menu heading when `ls` is run, instead of being with the rest.

## Pre

![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/a80181ef-b6fe-41c6-9913-ca320862928d)

## Post

(second from the bottom)
![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/f41bf6dd-0ffb-4b85-9645-cbc25999f47d)
