### PR TITLE
Fix aws-cli install in Dockerfile, breaking workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
 FROM python:3.9-alpine
 
 LABEL maintainer="Rhino Assessment Team <pacu@rhinosecuritylabs.com>"
-LABEL pacu.version="1.5.1"
+LABEL pacu.version="1.5.3"
 
+# Install necessary packages
 RUN apk add --no-cache \
-    aws-cli \
-    zip
+    python3 \
+    py3-pip \
+    zip \
+    curl \
+    unzip
+
+# Install AWS CLI using pip
+RUN pip3 install --upgrade pip \
+    && pip3 install awscli
 
 # Install Pacu
 WORKDIR /usr/src/pacu/
@@ -15,3 +23,4 @@ RUN pip install .
 RUN echo 'AWS_EC2_METADATA_DISABLED=true' >> /etc/profile
 
 ENTRYPOINT ["pacu"]
+


### PR DESCRIPTION
This updates the install method in the Dockerfile for aws-cli so that it works.