### PR TITLE
alias use to run/exec

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -108,7 +108,7 @@ def display_pacu_help():
                                               appended to the user agent for all API calls. If no suffix is
                                               supplied a UUID-based suffix will be generated.
         unset_ua_suffix                     Remove the user agent suffix for this session.
-        run/exec <module name>              Execute a module
+        run/exec/use <module name>          Execute a module
         set_keys                            Add a set of AWS keys to the session and set them as the
                                               default
         swap_keys                           Change the currently active AWS key to another key that has
@@ -176,10 +176,10 @@ def get_data_from_traceback(tb) -> Tuple[Optional[PacuSession], List[str], List[
 
 class Main:
     COMMANDS = [
-        'aws', 'data', 'exec', 'exit', 'help', 'import_keys', 'assume_role', 'list', 'load_commands_file',
-        'ls', 'quit', 'regions', 'run', 'search', 'services', 'set_keys', 'set_regions',
-        'swap_keys', 'update_regions', 'set_ua_suffix', 'unset_ua_suffix', 'whoami', 'swap_session', 'sessions',
-        'list_sessions', 'delete_session', 'export_keys', 'open_console', 'console'
+        'assume_role', 'aws', 'console', 'data', 'delete_session', 'exec', 'exit', 'export_keys', 'help',
+        'import_keys', 'list', 'list_sessions', 'load_commands_file', 'ls', 'open_console', 'quit', 'regions',
+        'run', 'search', 'services', 'sessions', 'set_keys', 'set_regions', 'set_ua_suffix', 'swap_keys',
+        'swap_session', 'unset_ua_suffix', 'update_regions', 'use', 'whoami'
     ]
 
     def __init__(self):
@@ -595,7 +595,7 @@ class Main:
             self.parse_commands_from_file(command)
         elif command[0] == 'regions':
             self.display_all_regions()
-        elif command[0] == 'run' or command[0] == 'exec':
+        elif command[0] in ['run', 'exec', 'use']:
             self.print_user_agent_suffix()
             self.parse_exec_module_command(command)
         elif command[0] == 'search':


### PR DESCRIPTION
Make pacu more friendly to users of other frameworks (metasploit) by aliasing `use` to `run` and `exec`