### PR TITLE
UX: Add -h to run/exec to display help

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -782,7 +782,9 @@ class Main:
                 self.list_modules(command[2], by_category=True)
 
     def parse_exec_module_command(self, command: List[str]) -> None:
-        if len(command) > 1:
+        if len(command) > 1 and command[-1] == "-h":
+            self.parse_help_command(command)
+        elif len(command) > 1:
             self.exec_module(command)
         else:
             print('The {} command requires a module name. Try using the module search function.'.format(command))


### PR DESCRIPTION
Some modules when run w/o arguments will have enough defaults to run the module. However, at times the user just wants to see more info about the module, but they may be unsure how to get a normal python `help` menu to appear for that module. While the `help` command exists, this adds another way to launch that vs a module by adding the `-h` flag to the end of the command.

Example:
![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/17307c95-36dd-4fad-98fc-be1585808f73)
