### PR TITLE
UX: history command

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import List, Optional, Any, Dict, Union, Tuple
 
 from pacu.core import lib
-from pacu.core.lib import session_dir, home_dir
+from pacu.core.lib import session_dir
 
 try:
     import jq  # type: ignore

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -45,7 +45,7 @@ except ModuleNotFoundError:
 
 # arbitrary number, seems reasonable though
 readline.set_history_length(200)
-readline.read_history_file(home_dir() + 'command_history.txt')
+readline.read_history_file(f'{home_dir()}/command_history.txt')
 
 def load_categories() -> set:
     categories = set()
@@ -633,7 +633,7 @@ class Main:
             self.print_key_info()
         elif command[0] == 'exit' or command[0] == 'quit':
             # write out command history for loading later
-            readline.write_history_file(home_dir() + 'command_history.txt')
+            readline.write_history_file(f'{home_dir()}/command_history.txt')
             self.exit()
         else:
             print('  Error: Unrecognized command')

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -48,6 +48,7 @@ readline.set_history_length(200)
 if os.path.isfile(f'{home_dir()}/command_history.txt') and os.access(f'{home_dir()}/command_history.txt', os.R_OK):
     readline.read_history_file(f'{home_dir()}/command_history.txt')
 
+
 def load_categories() -> set:
     categories = set()
     current_directory = os.getcwd()
@@ -184,8 +185,8 @@ class Main:
     COMMANDS = [
         'assume_role', 'aws', 'console', 'data', 'delete_session', 'exec', 'exit', 'export_keys', 'help',
         'history', 'import_keys', 'list', 'list_sessions', 'load_commands_file', 'ls', 'open_console', 'quit',
-        'regions','run', 'search', 'services', 'sessions', 'set_keys', 'set_regions', 'set_ua_suffix',
-        'swap_keys','swap_session', 'unset_ua_suffix', 'update_regions', 'use', 'whoami'
+        'regions', 'run', 'search', 'services', 'sessions', 'set_keys', 'set_regions', 'set_ua_suffix',
+        'swap_keys', 'swap_session', 'unset_ua_suffix', 'update_regions', 'use', 'whoami'
     ]
 
     def __init__(self):
@@ -376,7 +377,7 @@ class Main:
         # https://stackoverflow.com/a/7008316
         for i in range(readline.get_current_history_length()):
             print("{:>3}: {}".format(i+1, readline.get_history_item(i + 1)))
-    
+
     def display_all_regions(self):
         for region in sorted(self.get_regions('all')):
             print('  {}'.format(region))

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -371,7 +371,7 @@ class Main:
         # https://stackoverflow.com/a/7008316
         import readline
         for i in range(readline.get_current_history_length()):
-            print("{:>3}: {}".format(i,readline.get_history_item(i + 1)))
+            print("{:>3}: {}".format(i+1, readline.get_history_item(i + 1)))
     
     def display_all_regions(self):
         for region in sorted(self.get_regions('all')):

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -45,8 +45,8 @@ except ModuleNotFoundError:
 
 # arbitrary number, seems reasonable though
 readline.set_history_length(200)
-if os.path.isfile(f'{home_dir()}/command_history.txt') and os.access(f'{home_dir()}/command_history.txt', os.R_OK):
-    readline.read_history_file(f'{home_dir()}/command_history.txt')
+if os.path.isfile(settings.history_file) and os.access(settings.history_file, os.R_OK):
+    readline.read_history_file(settings.history_file)
 
 
 def load_categories() -> set:
@@ -635,7 +635,7 @@ class Main:
             self.print_key_info()
         elif command[0] == 'exit' or command[0] == 'quit':
             # write out command history for loading later
-            readline.write_history_file(f'{home_dir()}/command_history.txt')
+            readline.write_history_file(settings.history_file)
             self.exit()
         else:
             print('  Error: Unrecognized command')

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -45,7 +45,7 @@ except ModuleNotFoundError:
 
 # arbitrary number, seems reasonable though
 readline.set_history_length(200)
-if os.path.isfile(f'{home_dir()}/command_history.txt') and os.access(file, os.R_OK):
+if os.path.isfile(f'{home_dir()}/command_history.txt') and os.access(f'{home_dir()}/command_history.txt', os.R_OK):
     readline.read_history_file(f'{home_dir()}/command_history.txt')
 
 def load_categories() -> set:

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -371,7 +371,7 @@ class Main:
         # https://stackoverflow.com/a/7008316
         import readline
         for i in range(readline.get_current_history_length()):
-            print("{0:>3}: {}".format(i,readline.get_history_item(i + 1)))
+            print("{:>3}: {}".format(i,readline.get_history_item(i + 1)))
     
     def display_all_regions(self):
         for region in sorted(self.get_regions('all')):

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -45,7 +45,8 @@ except ModuleNotFoundError:
 
 # arbitrary number, seems reasonable though
 readline.set_history_length(200)
-readline.read_history_file(f'{home_dir()}/command_history.txt')
+if os.path.isfile(f'{home_dir()}/command_history.txt') and os.access(file, os.R_OK):
+    readline.read_history_file(f'{home_dir()}/command_history.txt')
 
 def load_categories() -> set:
     categories = set()

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -126,6 +126,7 @@ def display_pacu_help():
         swap_session <session name>         Change the active Pacu session to another one in the database
         delete_session                      Delete a Pacu session from the database. Note that the output
                                               folder for that session will not be deleted
+        history                             List the previously typed commands
 
         exit/quit                           Exit Pacu
 
@@ -179,7 +180,7 @@ class Main:
         'aws', 'data', 'exec', 'exit', 'help', 'import_keys', 'assume_role', 'list', 'load_commands_file',
         'ls', 'quit', 'regions', 'run', 'search', 'services', 'set_keys', 'set_regions',
         'swap_keys', 'update_regions', 'set_ua_suffix', 'unset_ua_suffix', 'whoami', 'swap_session', 'sessions',
-        'list_sessions', 'delete_session', 'export_keys', 'open_console', 'console'
+        'list_sessions', 'delete_session', 'export_keys', 'open_console', 'console', 'history'
     ]
 
     def __init__(self):
@@ -366,6 +367,12 @@ class Main:
         else:
             return valid_regions
 
+    def display_history(self):
+        # https://stackoverflow.com/a/7008316
+        import readline
+        for i in range(readline.get_current_history_length()):
+            print("{0:>3}: {}".format(i,readline.get_history_item(i + 1))
+    
     def display_all_regions(self):
         for region in sorted(self.get_regions('all')):
             print('  {}'.format(region))
@@ -595,6 +602,8 @@ class Main:
             self.parse_commands_from_file(command)
         elif command[0] == 'regions':
             self.display_all_regions()
+        elif command[0] == 'history':
+            self.display_history()
         elif command[0] == 'run' or command[0] == 'exec':
             self.print_user_agent_suffix()
             self.parse_exec_module_command(command)
@@ -780,7 +789,7 @@ class Main:
         elif len(command) == 3:
             if command[1] in ('cat', 'category'):
                 self.list_modules(command[2], by_category=True)
-
+    
     def parse_exec_module_command(self, command: List[str]) -> None:
         if len(command) > 1:
             self.exec_module(command)

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -795,7 +795,7 @@ class Main:
         elif len(command) == 3:
             if command[1] in ('cat', 'category'):
                 self.list_modules(command[2], by_category=True)
-    
+
     def parse_exec_module_command(self, command: List[str]) -> None:
         if len(command) > 1:
             self.exec_module(command)

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -606,13 +606,9 @@ class Main:
             self.parse_commands_from_file(command)
         elif command[0] == 'regions':
             self.display_all_regions()
-<<<<<<< HEAD
         elif command[0] == 'history':
             self.display_history()
-        elif command[0] == 'run' or command[0] == 'exec':
-=======
         elif command[0] in ['run', 'exec', 'use']:
->>>>>>> master
             self.print_user_agent_suffix()
             self.parse_exec_module_command(command)
         elif command[0] == 'search':

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -371,7 +371,7 @@ class Main:
         # https://stackoverflow.com/a/7008316
         import readline
         for i in range(readline.get_current_history_length()):
-            print("{0:>3}: {}".format(i,readline.get_history_item(i + 1))
+            print("{0:>3}: {}".format(i,readline.get_history_item(i + 1)))
     
     def display_all_regions(self):
         for region in sorted(self.get_regions('all')):

--- a/pacu/main.py
+++ b/pacu/main.py
@@ -5,6 +5,7 @@ import json
 import os
 import random
 import re
+import readline
 import shlex
 import subprocess
 import sys
@@ -16,7 +17,7 @@ from pathlib import Path
 from typing import List, Optional, Any, Dict, Union, Tuple
 
 from pacu.core import lib
-from pacu.core.lib import session_dir
+from pacu.core.lib import session_dir, home_dir
 
 try:
     import jq  # type: ignore
@@ -42,6 +43,9 @@ except ModuleNotFoundError:
     print('Refer to https://github.com/RhinoSecurityLabs/pacu/wiki/Installation')
     sys.exit(1)
 
+# arbitrary number, seems reasonable though
+readline.set_history_length(200)
+readline.read_history_file(home_dir() + 'command_history.txt')
 
 def load_categories() -> set:
     categories = set()
@@ -369,7 +373,6 @@ class Main:
 
     def display_history(self):
         # https://stackoverflow.com/a/7008316
-        import readline
         for i in range(readline.get_current_history_length()):
             print("{:>3}: {}".format(i+1, readline.get_history_item(i + 1)))
     
@@ -629,6 +632,8 @@ class Main:
         elif command[0] == 'whoami':
             self.print_key_info()
         elif command[0] == 'exit' or command[0] == 'quit':
+            # write out command history for loading later
+            readline.write_history_file(home_dir() + 'command_history.txt')
             self.exit()
         else:
             print('  Error: Unrecognized command')
@@ -1586,7 +1591,6 @@ aws_secret_access_key = {}
 
     def initialize_tab_completion(self) -> None:
         try:
-            import readline
             # Big thanks to samplebias: https://stackoverflow.com/a/5638688
             MODULES = []
             CATEGORIES = []

--- a/pacu/settings.py
+++ b/pacu/settings.py
@@ -17,6 +17,8 @@ ERROR_LOG_VERBOSITY = 'minimal'
 _home_dir = Path('~/.local/share/pacu')
 home_dir = _home_dir.expanduser().absolute()
 
+history_file = f'{home_dir}/command_history.txt'
+
 os.makedirs(home_dir, exist_ok=True, mode=0o700)
 
 DATABASE_FILE_PATH = os.path.join(home_dir, 'sqlite.db')


### PR DESCRIPTION
Adds a history command, saved at exit (not `ctr+c`, assuming that's a bail at all costs method) and loaded at startup. Saved across sessions.

![image](https://github.com/RhinoSecurityLabs/pacu/assets/752491/48956f29-1628-4675-8e4b-23d076517934)
