### PR TITLE
Fixed the apigateway__enum module

### DIFF
--- a/pacu/modules/apigateway__enum/main.py
+++ b/pacu/modules/apigateway__enum/main.py
@@ -1,15 +1,10 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
-from pathlib import Path
 import pprint
 import json
-import time
 from copy import deepcopy
 
-from pacu.core.lib import downloads_dir
-from pacu.core.lib import strip_lines
 from pacu import Main
 
 module_info = {
@@ -34,34 +29,21 @@ parser.add_argument(
 
 pp = pprint.PrettyPrinter(indent=2)
 
-
 # Get all resources for API
-#
-# return [] dict
 def get_api_resources(client, api_id):
     response = client.get_resources(restApiId=api_id)
     return response['items']
 
-
 # Get All deployment stages of API
-#
-# returns [] string
 def get_api_stages(client, api_id):
     response = client.get_stages(restApiId=api_id)
-    names = []
-    for stage in response['item']:
-        if(stage.get('stageName')):
-            names.append(stage['stageName'])
-    return names
-
+    return [stage['stageName'] for stage in response['item'] if stage.get('stageName')]
 
 # Get all supported methods per api resources "/users"
-#
-# Returns [] dict
 def get_api_methods(client, api_id, resource):
     routes = []
     if resource.get('resourceMethods'):
-        for method in resource.get('resourceMethods'):
+        for method in resource['resourceMethods']:
             response = client.get_method(
                 restApiId=api_id,
                 resourceId=resource['id'],
@@ -69,7 +51,6 @@ def get_api_methods(client, api_id, resource):
             )
             routes.append(response)
     return routes
-
 
 def get_api_keys(client):
     try:
@@ -80,44 +61,32 @@ def get_api_keys(client):
         print(f"Failed to get API keys: {e}")
     return []
 
-
 def get_client_certs(client):
-    try:
-        response = client.get_client_certificates(limit=500)
-        data = []
-        if response.get('items'):
-            for cert in response['items']:
-                res = client.get_client_certificate(clientCertificateId=cert['clientCertificateId'])
-                cert['pemEncodedCertificate'] = res['pemEncodedCertificate']
-            data.append(cert)
-        return data
-    except client.exceptions.ClientError as e:
-        print(f"Failed to get client certificates: {e}")
-    return []
-
+    response = client.get_client_certificates(limit=500)
+    data = []
+    if response.get('items'):
+        for cert in response['items']:
+            res = client.get_client_certificate(clientCertificateId=cert['clientCertificateId'])
+            cert['pemEncodedCertificate'] = res['pemEncodedCertificate']
+        data.append(cert)
+    return data
 
 # If permissions supported export the API documentation as Swagger File
-def export_api_doc(client, session, api_summary, exportType='swagger'):
-
-    files_names = []
-    output_path = downloads_dir()/'apigateway'
-    output_path.mkdir(exist_ok=True)
-
+def export_api_doc(client, api_summary, exportType='swagger'):
+    docs = []
     api_id = api_summary['id']
     api_name = api_summary['name']
     stages = api_summary['stages']
 
     for stage in stages:
         response = client.get_export(restApiId=api_id, stageName=stage, exportType=exportType)
-        filename = f"{api_name}_{stage}_swagger.json"
-        with open(output_path / filename, 'w') as f:
-            data = json.loads(response['body'].read().decode("utf-8"))
-            json.dump(data, f, indent=4)
+        data = json.loads(response['body'].read().decode("utf-8"))
+        docs.append({
+            'stage': stage,
+            'content': json.dumps(data, indent=4)
+        })
 
-        files_names.append(filename)
-
-    return files_names
-
+    return docs
 
 # Take method obj and parse into method summary
 def parse_method(base_url, method, path, stages):
@@ -150,97 +119,55 @@ def parse_method(base_url, method, path, stages):
 
     return api_method
 
-
 def main(args, pacu_main: "Main"):
     """Main module function, called from Pacu"""
-    session = pacu_main.get_active_session()
     print = pacu_main.print
+    session = pacu_main.get_active_session()
     args = parser.parse_args(args)
-
-    outfile_path = downloads_dir()/'apigateway'
 
     if args.regions:
         regions = args.regions.split(',')
     else:
         regions = pacu_main.get_regions('apigateway')
 
-    # Set up summary data object
     summary_data = {'apis': [], 'apiKeys': [], 'clientCerts': []}
 
     for region in regions:
         client = pacu_main.get_boto3_client('apigateway', region)
         print(f"Enumerating {region}")
 
-        # Get global API data
-        try:
-            summary_data['apiKeys'] = get_api_keys(client)
-        except Exception as e:
-            print(f"Failed to get API Keys in {region}: {e}")
-        try:
-            summary_data['clientCerts'] = get_client_certs(client)
-        except Exception as e:
-            print(f"Failed to get Client Certs in {region}: {e}")
+        summary_data['apiKeys'] = get_api_keys(client)
+        summary_data['clientCerts'] = get_client_certs(client)
 
-        # Currently this only supports REST apis
-        # Get all apis in AWS Gateway
-        try:
-            response = client.get_rest_apis()
-        except Exception as e:
-            print(f"Failed to get APIs in {region}: {e}")
-            continue
-
+        response = client.get_rest_apis()
         items = response['items']
 
-        # for each api in the account
         for api in items:
-
-            # create api object summary
             api_summary = {
-                'id': '',
-                'name': '',
-                'stages': [],
-                'urlBase': "",
+                'id': api['id'],
+                'name': api['name'],
+                'stages': get_api_stages(client, api['id']),
+                'urlBase': f"https://{api['id']}.execute-api.{region}.amazonaws.com/",
                 'urlPaths': [],
                 "apiDocs": []
             }
 
-            # Set up base info used by methods
-            api_summary['id'] = api['id']
-            api_summary['name'] = api['name']
-            api_summary['stages'] = get_api_stages(client, api_summary['id'])
-            api_summary['urlBase'] = f"https://{api_summary['id']}.execute-api.{region}.amazonaws.com/"
-
             print(f"Enumerating API: {api_summary['name']}")
 
-            # For each resource get all methods and parse it into its method summary.
-            for resource in get_api_resources(client, api_summary['id']):
-                for method in get_api_methods(client, api_summary['id'], resource):
+            for resource in get_api_resources(client, api['id']):
+                for method in get_api_methods(client, api['id'], resource):
                     api_summary['urlPaths'].append(parse_method(api_summary['urlBase'], method, resource['path'], api_summary['stages']))
 
-            # Append api results to main summary
             summary_data['apis'].append(api_summary)
-
-            # attempt to export api_docs
-            api_summary['apiDocs'] = export_api_doc(client, session, api_summary)
-
-        # Write summary all data to downloads file
-        if(len(summary_data['apis']) > 0):
-            print("Writing all results to file: {}/".format(outfile_path))
-            filename = f"apigateway_{region}_{time.time()}.json"
-            with open(outfile_path / filename, "w+") as f:
-                f.write(
-                    json.dumps(summary_data, indent=4, default=str)
-                )
-            f.close()
+            api_summary['apiDocs'] = export_api_doc(client, api_summary)
 
     # Write all the data to the database for storage
-    api_data = deepcopy(session.APIGateway)
+    apigateway_data = deepcopy(session.APIGateway)
     for key, value in summary_data.items():
-        api_data[key] = value
-    session.update(pacu_main.database, APIGateway=api_data)
+        apigateway_data[key] = value
+    session.update(pacu_main.database, APIGateway=apigateway_data)
 
     return summary_data
-
 
 def summary(data, pacu_main):
     msg = ''
@@ -249,25 +176,21 @@ def summary(data, pacu_main):
     else:
         msg = "Data saved to session file."
 
-        # Display all API routes
         print("-----API Routes-----")
         for api in data['apis']:
             print(f"\n\tAPI Name: {api['name']}")
             print(f"\tAPI Stages: {', '.join(api['stages'])}")
-            print(f"\tExported Documentation: { ', '.join(api['apiDocs'])  } ")
+            print(f"\tExported Documentation: {[doc['stage'] for doc in api['apiDocs']]}")
 
             for url_paths in api['urlPaths']:
-                # print a new http url for each staged version
                 [print(f"\t\t {url_paths['method']}: {url}") for url in url_paths['url']]
 
-        # Display Global API keys
         print("-----API Keys-----")
         for key in data['apiKeys']:
             print(f"\tKey Name: {key['name']} \n\t\tValue: {key['value']} \n\t\tcreatedDate: {key['createdDate']}")
 
-        # Display Global Client Certs
         print("-----Client Certs-----")
         for cert in data['clientCerts']:
             print(f"\tCert Id: {cert['clientCertificateId']} \n\t\texpirationDate: {cert['expirationDate']} \n\t\tpem: {cert['pemEncodedCertificate']}")
 
-    return(msg)
+    return msg

--- a/pacu/modules/apigateway__enum/main.py
+++ b/pacu/modules/apigateway__enum/main.py
@@ -136,10 +136,24 @@ def main(args, pacu_main: "Main"):
         client = pacu_main.get_boto3_client('apigateway', region)
         print(f"Enumerating {region}")
 
-        summary_data['apiKeys'] = get_api_keys(client)
-        summary_data['clientCerts'] = get_client_certs(client)
+        # Get global API data
+        try:
+            summary_data['apiKeys'] = get_api_keys(client)
+        except Exception as e:
+            print(f"Failed to get API Keys in {region}: {e}")
+        try:
+            summary_data['clientCerts'] = get_client_certs(client)
+        except Exception as e:
+            print(f"Failed to get Client Certs in {region}: {e}")
 
-        response = client.get_rest_apis()
+        # Currently this only supports REST apis
+        # Get all apis in AWS Gatway
+        try:
+            response = client.get_rest_apis()
+        except Exception as e:
+            print(f"Failed to get APIs in {region}: {e}")
+            continue
+
         items = response['items']
 
         for api in items:


### PR DESCRIPTION
- If the user has "GET" permissions on API Gateways but not the API Keys, the module will still get all the paths/methods/resources rather than failing

- There was no error handling on "all regions" so it would fail. Added error handling so the user can check all regions without issues

- Previously it saved the data to a standalone file, updated this so it stores to the Pacu DB like other modules