### PR TITLE
- Update iam__enum_permissions module 

### DIFF
--- a/pacu/modules/iam__enum_permissions/main.py
+++ b/pacu/modules/iam__enum_permissions/main.py
@@ -569,7 +569,6 @@ def summary(data, pacu_main):
     else:
         out += "{:>{count_max_len}} Unconfirmed permissions for {} role(s).\n".format(data["roles_unconfirmed_perm_count"],
                                                                                       data["roles_unconfirmed"],
-    
                                                                                       count_max_len=count_max_len)
     out += "Type 'whoami' to see detailed list of permissions.\n" 
     return out

--- a/pacu/modules/iam__enum_permissions/main.py
+++ b/pacu/modules/iam__enum_permissions/main.py
@@ -569,7 +569,9 @@ def summary(data, pacu_main):
     else:
         out += "{:>{count_max_len}} Unconfirmed permissions for {} role(s).\n".format(data["roles_unconfirmed_perm_count"],
                                                                                       data["roles_unconfirmed"],
+    
                                                                                       count_max_len=count_max_len)
+    out += "Type 'whoami' to see detailed list of permissions.\n" 
     return out
 
 


### PR DESCRIPTION
When a user runs "iam__enum_permissions", the module provides them with an overview of permissions in this format:
```
[iam__enum_permissions] MODULE SUMMARY:

  11 Confirmed permissions for user: cg-sns-user-sns_secrets_cgid01anefb2lz.
   0 Confirmed permissions for 0 role(s).
   0 Unconfirmed permissions for 0 user(s).
   0 Unconfirmed permissions for 0 role(s).
```
It's likely because I'm a Pacu noob, but it took me some time to figure out how to actually read the permissions it enumerated. This very minor fix will tell the user to type "whoami" to see a detailed list of permissions to save time for noobs like me when first using the module. 

![image](https://github.com/RhinoSecurityLabs/pacu/assets/86263907/9eb5ceaa-826f-4669-9375-cbd7eb0ca6ae)

