### PR TITLE
Fix SyntaxWarning: invalid escape sequence (Python 3.12)

### DIFF
--- a/pacu/modules/iam__backdoor_users_password/main.py
+++ b/pacu/modules/iam__backdoor_users_password/main.py
@@ -126,7 +126,7 @@ def summary(data, pacu_main):
 
 
 def create_valid_password(password_policy: None) -> str:
-    symbols = '!@#$%^&*()_+=-\][{}|;:",./?><`~'
+    symbols = r'!@#$%^&*()_+=-\][{}|;:",./?><`~'
     password = ''.join(choice(string.ascii_lowercase) for _ in range(3))
     try:
         if password_policy['RequireNumbers'] is True:

--- a/pacu/modules/systemsmanager__rce_ec2/main.py
+++ b/pacu/modules/systemsmanager__rce_ec2/main.py
@@ -82,10 +82,10 @@ def main(args, pacu_main):
 
     if args.all_instances is False and args.target_instances is None:
         os_with_default_ssm_agent = [
-            '[\s\S]*Windows[\s\S]*Server[\s\S]*',
-            '[\s\S]*Amazon[\s\S]*Linux[\s\S]*',
-            '[\s\S]*Ubuntu[\s\S]*Server[\s\S]*16\\.04[\s\S]*',
-            '[\s\S]*Ubuntu[\s\S]*Server[\s\S]*18\\.04[\s\S]*',
+            r'[\s\S]*Windows[\s\S]*Server[\s\S]*',
+            r'[\s\S]*Amazon[\s\S]*Linux[\s\S]*',
+            r'[\s\S]*Ubuntu[\s\S]*Server[\s\S]*16\\.04[\s\S]*',
+            r'[\s\S]*Ubuntu[\s\S]*Server[\s\S]*18\\.04[\s\S]*',
             # 'Windows Server 2003-2012 R2 released after November 2016'
         ]
 


### PR DESCRIPTION
```
.pybuild/cpython3_3.12_pacu/build/tests/test_pacu_data_command.py::test_parse_data_command_returns_help
  /<<PKGBUILDDIR>>/.pybuild/cpython3_3.12_pacu/build/pacu/modules/iam__backdoor_users_password/main.py:129: SyntaxWarning: invalid escape sequence '\]'
    symbols = '!@#$%^&*()_+=-\][{}|;:",./?><`~'

.pybuild/cpython3_3.12_pacu/build/tests/test_pacu_data_command.py::test_parse_data_command_returns_help
  /<<PKGBUILDDIR>>/.pybuild/cpython3_3.12_pacu/build/pacu/modules/systemsmanager__rce_ec2/main.py:85: SyntaxWarning: invalid escape sequence '\s'
    '[\s\S]*Windows[\s\S]*Server[\s\S]*',

.pybuild/cpython3_3.12_pacu/build/tests/test_pacu_data_command.py::test_parse_data_command_returns_help
  /<<PKGBUILDDIR>>/.pybuild/cpython3_3.12_pacu/build/pacu/modules/systemsmanager__rce_ec2/main.py:86: SyntaxWarning: invalid escape sequence '\s'
    '[\s\S]*Amazon[\s\S]*Linux[\s\S]*',

.pybuild/cpython3_3.12_pacu/build/tests/test_pacu_data_command.py::test_parse_data_command_returns_help
  /<<PKGBUILDDIR>>/.pybuild/cpython3_3.12_pacu/build/pacu/modules/systemsmanager__rce_ec2/main.py:87: SyntaxWarning: invalid escape sequence '\s'
    '[\s\S]*Ubuntu[\s\S]*Server[\s\S]*16\\.04[\s\S]*',

.pybuild/cpython3_3.12_pacu/build/tests/test_pacu_data_command.py::test_parse_data_command_returns_help
  /<<PKGBUILDDIR>>/.pybuild/cpython3_3.12_pacu/build/pacu/modules/systemsmanager__rce_ec2/main.py:88: SyntaxWarning: invalid escape sequence '\s'
    '[\s\S]*Ubuntu[\s\S]*Server[\s\S]*18\\.04[\s\S]*',
```