### PR TITLE
fix ecs__enum crash on permission denied

### DIFF
--- a/pacu/modules/ecs__enum/main.py
+++ b/pacu/modules/ecs__enum/main.py
@@ -103,6 +103,7 @@ def main(args, pacu_main):
                     response = client.list_clusters()
                 except ClientError as error:
                     code = error.response['Error']['Code']
+                    response = {}
                     print('FAILURE: ')
                     if code == 'UnauthorizedOperation':
                         print('  Access denied to ListClusters.')
@@ -113,7 +114,7 @@ def main(args, pacu_main):
                 else:
                     response = client.list_clusters()
 
-                for arn in response['clusterArns']:
+                for arn in response.get('clusterArns', []):
                     clusters.append(arn)
             print('  {} cluster arn(s) found.'.format(len(clusters)))
             all_clusters += clusters


### PR DESCRIPTION
# Problem

When using `ecs__enum` without cluster list permissions, we get the following output:
```
Pacu (blackbox2:imported-arte) > run ecs__enum --region us-east-1
  Running module ecs__enum...
[ecs__enum] Starting region us-east-1...
[ecs__enum] FAILURE: 
[ecs__enum]   AccessDeniedException
[ecs__enum]     Skipping cluster enumeration...

[2024-09-12 16:28:04] Pacu encountered an error while running the previous command. Check /root/.local/share/pacu/blackbox2/error_log.txt for technical details, or use the debug command. [LOG LEVEL: MINIMAL]

    <class 'TypeError'>: 'NoneType' object is not subscriptable
```

Checking the error message we see:
```
[2024-09-12 16:18:03] (blackbox2): 
Traceback (most recent call last):
  File "/root/pacu/pacu/main.py", line 1855, in run_gui
    self.idle()
  File "/root/pacu/pacu/main.py", line 1711, in idle
    self.idle()
  File "/root/pacu/pacu/main.py", line 1711, in idle
    self.idle()
  File "/root/pacu/pacu/main.py", line 1711, in idle
    self.idle()
  [Previous line repeated 4 more times]
  File "/root/pacu/pacu/main.py", line 1709, in idle
    self.parse_command(command)
  File "/root/pacu/pacu/main.py", line 623, in parse_command
    self.parse_exec_module_command(command)
  File "/root/pacu/pacu/main.py", line 815, in parse_exec_module_command
    self.exec_module(command)
  File "/root/pacu/pacu/main.py", line 1032, in exec_module
    summary_data = module.main(command[2:], self)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pacu/pacu/modules/ecs__enum/main.py", line 116, in main
    for arn in response['clusterArns']:
               ~~~~~~~~^^^^^^^^^^^^^^^
<class 'TypeError'>: 'NoneType' object is not subscriptable
```

# Solution

Generate the object which is expected, then gracefully handle accessing items that aren't there.

New output:

```
Pacu (blackbox2:imported-arte) > run ecs__enum --region us-east-1
  Running module ecs__enum...
[ecs__enum] Starting region us-east-1...
[ecs__enum] FAILURE: 
[ecs__enum]   AccessDeniedException
[ecs__enum]     Skipping cluster enumeration...
[ecs__enum]   0 cluster arn(s) found.
[ecs__enum]   0 container(s) found.
[ecs__enum]   0 service(s) found.
[ecs__enum] FAILURE: 
[ecs__enum]   AccessDeniedException
[ecs__enum]   Skipping instance enumeration...
[ecs__enum]   0 task definition(s) found.
[ecs__enum] ecs__enum completed.

[ecs__enum] MODULE SUMMARY:

  Regions:
     us-east-1

    0 total cluster(s) found.
    0 total container(s) found.
    0 total service(s) found.
```
