### PR TITLE
Fix directory creation error on dynamodb__enum

### DIFF
--- a/pacu/modules/dynamodb__enum/main.py
+++ b/pacu/modules/dynamodb__enum/main.py
@@ -157,7 +157,7 @@ def summary(data, pacu_main):
 
 def writeTableData(directory, table, data):
     if not os.path.exists(directory):
-        os.mkdir(directory)
+        os.makedirs(directory, exist_ok=True)
     path = os.path.join(directory, table + '.txt')
     with open(path, 'w+') as writeTableDump:
         writeTableDump.write(pprint.pformat(data))


### PR DESCRIPTION
This pull request addresses a FileNotFoundError encountered during the DynamoDB table dump process . 

The error occurred because the code was attempting to create a nested directory structure using os.mkdir, which only creates the final directory in the given path. If any intermediate directories were missing, the command would fail.

To resolve the issue, I replaced os.mkdir with os.makedirs(directory, exist_ok=True), ensuring that all necessary intermediate directories are created automatically. This change makes the module more robust and prevents the error when the expected directory structure is not present.