### PR TITLE
Beanstalk Module Patch

### DIFF
--- a/pacu/modules/beanstalk__enum/main.py
+++ b/pacu/modules/beanstalk__enum/main.py
@@ -10,7 +10,7 @@ from pacu.core.secretfinder.utils import regex_checker, Color
 from pacu.core.lib import save, downloads_dir
 
 module_info = {
-    'name': 'elasticbeanstalk__enum',
+    'name': 'beanstalk__enum',
     'author': 'Tyler Ramsbey',
     'category': 'ENUM',
     'one_liner': 'Enumerates Elastic Beanstalk applications, environments, checks for secrets.',

--- a/pacu/modules/beanstalk__enum/main.py
+++ b/pacu/modules/beanstalk__enum/main.py
@@ -17,7 +17,8 @@ module_info = {
     'description': (
         'Enumerates Elastic Beanstalk applications, environments, configuration settings, '
         'and tags, scanning for possible secrets in environment variables and source code. '
-        'This will also download the source code for the deployed application for static review.'
+        'By default, this will not download the source code. To download the source code, '
+        'use the --source flag.'
     ),
     'services': ['BeanStalk'],
     'prerequisite_modules': [],
@@ -64,9 +65,9 @@ def main(args, pacu_main):
     # Use "beanstalk" (lowercase) to get regions from the session configuration.
     get_regions = pacu_main.get_regions
 
-    # If no flags are specified, enumerate everything
+    # If no flags are specified, enumerate everything except source code
     if not any([args.applications, args.environments, args.config, args.tags, args.source]):
-        args.applications = args.environments = args.config = args.tags = args.source = True
+        args.applications = args.environments = args.config = args.tags = True
 
     # Use "beanstalk" to get regions
     if args.regions is None:


### PR DESCRIPTION
### Overview of Changes:
1. The module only downloads the source code if the user specifies --source (before it would download automatically). This is so users do not accidently download large packages of source code on accident, if they just want to enumerate for other secrets. 

2. I update the module name in the "help" area because it was incorrect