### PR TITLE
fix: resolve --version returning unknown in Docker

### DIFF
--- a/pacu/main.py
+++ b/pacu/main.py
@@ -462,11 +462,13 @@ class Main:
 
     def get_pacu_version(self):
         try:
-            # Get the directory where this file is located
+            from importlib.metadata import version
+            return version('pacu')
+        except Exception:
+            pass
+        try:
             current_dir = os.path.dirname(__file__)
-            # Go up one level to the root of package
             package_root = os.path.abspath(os.path.join(current_dir, os.pardir))
-            # Construct the path to pyproject.toml
             toml_path = os.path.join(package_root, 'pyproject.toml')
             with open(toml_path, 'r') as file:
                 pyproject = toml.load(file)


### PR DESCRIPTION
Closes #486

`get_pacu_version()` reads `pyproject.toml` by walking up from `pacu/main.py`.
After `pip install .` (as the Dockerfile does), the code runs from site-packages
where `pyproject.toml` doesn't exist, so it falls back to "unknown".

Fix: use `importlib.metadata.version()` (stdlib since Python 3.8) as the primary
source. This reads from installed package metadata, which `pip install` populates
correctly. The `pyproject.toml` fallback stays for development installs.