### PR TITLE
fix: false positive success message in iam__privesc_scan

### DIFF
--- a/pacu/modules/iam__privesc_scan/main.py
+++ b/pacu/modules/iam__privesc_scan/main.py
@@ -1172,7 +1172,7 @@ def main(args, pacu_main: "Main"):
                     )
                     response = False
 
-                if response is False:
+                if not response:
                     print("  Method failed. Trying next potential method...")
                 else:
                     escalated = True
@@ -1202,7 +1202,7 @@ def main(args, pacu_main: "Main"):
                     )
                     response = False
 
-                if response is False:
+                if not response:
                     print("  Method failed. Trying next potential method...")
                 else:
                     escalated = True


### PR DESCRIPTION
Closes #483

`iam__privesc_scan` reports "Privilege escalation was successful" even
when every method fails. The check `if response is False` uses identity
comparison, so if an escalation method returns `None` (e.g. falling through
a try/except without an explicit return), `None is False` evaluates to
`False` and the code treats it as a success.

Fix: change `if response is False` to `if not response` so that `None`,
`False`, and any other falsy return value is correctly treated as failure.