### PR TITLE
chore: migrate dev-dependencies to poetry group syntax

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2731,4 +2731,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "18a6d150487df73ef31f4b7effda2adebbb07cf7098795267cf724420da20554"
+content-hash = "e709fe9388303f083b276a979dece0ddd2ee71b094f84c9faf499fd3c0ae734e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pyyaml = "^6.0.1"
 toml = "^0.10.2"
 types-urllib3 = "^1.26.25.14"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 flake8 = "^7.3.0"
 mypy = "^1.0"
 pytest = "^8.4.2"
@@ -38,8 +38,6 @@ typing-extensions = "^4.0.0"
 boto3-stubs = {extras = ["iam", "s3", "lambda"], version = "^1.17.54"}
 moto = "^5.1.22"
 importlib-metadata = "4.13.0"
-
-[tool.poetry.group.dev.dependencies]
 types-urllib3 = "^1.26.25.14"
 
 [build-system]


### PR DESCRIPTION
Move dependencies from the deprecated [tool.poetry.dev-dependencies] section to [tool.poetry.group.dev.dependencies].