### PR TITLE
fix(sns__enum): paginate list_topics and list_subscriptions_by_topic to prevent enumeration false-negatives

### DIFF
--- a/pacu/modules/sns__enum/main.py
+++ b/pacu/modules/sns__enum/main.py
@@ -74,7 +74,7 @@ def main(args, pacu_main: "Main"):
             # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns/client/list_topics.html
             response = client.list_topics()
             all_topics.extend(response["Topics"])
-            while "NextToken" in response:
+            while "NextToken" in response and response["NextToken"] != "":
                 response = client.list_topics(NextToken=response["NextToken"])
                 all_topics.extend(response["Topics"])
         except Exception as error:
@@ -119,7 +119,7 @@ def main(args, pacu_main: "Main"):
                     TopicArn=topic["TopicArn"]
                 )
                 all_subscriptions = sub_response["Subscriptions"]
-                while "NextToken" in sub_response:
+                while "NextToken" in sub_response and sub_response["NextToken"] != "":
                     sub_response = client.list_subscriptions_by_topic(
                         TopicArn=topic["TopicArn"],
                         NextToken=sub_response["NextToken"],

--- a/pacu/modules/sns__enum/main.py
+++ b/pacu/modules/sns__enum/main.py
@@ -67,10 +67,16 @@ def main(args, pacu_main: "Main"):
             print("Unable to connect to SNS service. Error: {}".format(error))
             continue
 
+        # Paginate list_topics — SNS caps each page at 100 topics.
+        # A single call silently under-reports in accounts with >100 topics.
+        all_topics = []
         try:
             # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns/client/list_topics.html
             response = client.list_topics()
-
+            all_topics.extend(response["Topics"])
+            while "NextToken" in response:
+                response = client.list_topics(NextToken=response["NextToken"])
+                all_topics.extend(response["Topics"])
         except Exception as error:
             print(
                 "Unable to list Topics; Check credentials or No topics are available. Error: {}".format(
@@ -78,14 +84,14 @@ def main(args, pacu_main: "Main"):
                 )
             )
             continue
-        print("  Found {} topics".format(len(response["Topics"])))
+        print("  Found {} topics".format(len(all_topics)))
 
         # don't store empty data
-        if len(response["Topics"]) == 0:
+        if len(all_topics) == 0:
             del(summary_data["sns"][region])
             continue
 
-        for topic in response["Topics"]:
+        for topic in all_topics:
             # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns/client/get_topic_attributes.html
             topic_details = client.get_topic_attributes(TopicArn=topic["TopicArn"])
             topic_details = topic_details["Attributes"]
@@ -103,14 +109,23 @@ def main(args, pacu_main: "Main"):
                 topic_details["SubscriptionsPending"]
             )
 
+            # Paginate list_subscriptions_by_topic — SNS caps each page at 100
+            # subscriptions per topic. A single call silently under-reports in
+            # topics with >100 subscribers.
             summary_data["sns"][region][topic["TopicArn"]]["Subscribers"] = []
             try:
                 # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns/client/list_subscriptions_by_topic.html
-                subscribers = client.list_subscriptions_by_topic(
+                sub_response = client.list_subscriptions_by_topic(
                     TopicArn=topic["TopicArn"]
                 )
-                subscribers = subscribers["Subscriptions"]
-                for subscriber in subscribers:
+                all_subscriptions = sub_response["Subscriptions"]
+                while "NextToken" in sub_response:
+                    sub_response = client.list_subscriptions_by_topic(
+                        TopicArn=topic["TopicArn"],
+                        NextToken=sub_response["NextToken"],
+                    )
+                    all_subscriptions.extend(sub_response["Subscriptions"])
+                for subscriber in all_subscriptions:
                     summary_data["sns"][region][topic["TopicArn"]][
                         "Subscribers"
                     ].append(

--- a/pacu/modules/sns__enum/tests/test_sns__enum.py
+++ b/pacu/modules/sns__enum/tests/test_sns__enum.py
@@ -15,7 +15,6 @@ import unittest.mock
 
 import boto3
 import moto
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -223,3 +222,103 @@ def test_empty_region_excluded_from_result():
     assert region not in result["sns"], (
         "Empty region should be excluded from result dict"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: a terminal page carrying an EMPTY NextToken must end the loop
+# ---------------------------------------------------------------------------
+
+class _EmptyTokenClient:
+    """
+    Fake SNS client whose last page returns ``NextToken: ""`` rather than
+    omitting the key.  A bare ``while "NextToken" in response`` loop never
+    terminates against this shape, so the loop guard must also test for the
+    empty string -- matching the idiom already used by ``glue__enum`` and
+    ``transfer_family__enum``.
+    """
+
+    #: hard cap so a regression fails fast instead of hanging the suite
+    MAX_CALLS = 25
+
+    def __init__(self):
+        self.topic_calls = 0
+        self.sub_calls = 0
+
+    def list_topics(self, **kwargs):
+        self.topic_calls += 1
+        if self.topic_calls > self.MAX_CALLS:
+            raise AssertionError(
+                "list_topics paged more than {} times: the NextToken loop did "
+                "not terminate on an empty token".format(self.MAX_CALLS)
+            )
+        if "NextToken" not in kwargs:
+            return {
+                "Topics": [{"TopicArn": "arn:aws:sns:us-east-1:000000000000:page1"}],
+                "NextToken": "page-2",
+            }
+        return {
+            "Topics": [{"TopicArn": "arn:aws:sns:us-east-1:000000000000:page2"}],
+            "NextToken": "",
+        }
+
+    def get_topic_attributes(self, TopicArn):
+        return {
+            "Attributes": {
+                "DisplayName": "",
+                "Owner": "000000000000",
+                "SubscriptionsConfirmed": "1",
+                "SubscriptionsPending": "0",
+            }
+        }
+
+    def list_subscriptions_by_topic(self, **kwargs):
+        self.sub_calls += 1
+        if self.sub_calls > self.MAX_CALLS:
+            raise AssertionError(
+                "list_subscriptions_by_topic paged more than {} times: the "
+                "NextToken loop did not terminate on an empty token".format(
+                    self.MAX_CALLS
+                )
+            )
+        if "NextToken" not in kwargs:
+            return {
+                "Subscriptions": [
+                    {"Protocol": "email", "Endpoint": "a@example.com"}
+                ],
+                "NextToken": "page-2",
+            }
+        return {
+            "Subscriptions": [
+                {"Protocol": "email", "Endpoint": "b@example.com"}
+            ],
+            "NextToken": "",
+        }
+
+
+def test_empty_next_token_terminates_pagination():
+    from pacu.modules.sns__enum.main import main
+
+    region = "us-east-1"
+    client = _EmptyTokenClient()
+
+    pacu_main = _make_pacu_main(lambda service, reg: client)
+    result = main(["--regions", region], pacu_main)
+
+    # Two pages of topics, both collected, and the loop stopped.
+    assert client.topic_calls == 2, (
+        "Expected exactly 2 list_topics calls, got {}".format(client.topic_calls)
+    )
+    assert len(result["sns"][region]) == 2
+
+    # Same for subscriptions, per topic (2 topics x 2 pages).
+    assert client.sub_calls == 4, (
+        "Expected exactly 4 list_subscriptions_by_topic calls, got {}".format(
+            client.sub_calls
+        )
+    )
+    for topic_arn, topic in result["sns"][region].items():
+        assert len(topic["Subscribers"]) == 2, (
+            "Expected 2 subscribers for {}, got {}".format(
+                topic_arn, len(topic["Subscribers"])
+            )
+        )

--- a/pacu/modules/sns__enum/tests/test_sns__enum.py
+++ b/pacu/modules/sns__enum/tests/test_sns__enum.py
@@ -1,0 +1,225 @@
+"""
+Tests for sns__enum pagination fix.
+
+Regression coverage for the false-negative introduced by calling
+list_topics() and list_subscriptions_by_topic() exactly once per
+invocation.  SNS paginates both APIs at 100 items per page, so any
+account with >100 topics (or >100 subscriptions on a single topic)
+was silently under-reported.
+
+The tests below drive the patched main() through a mock boto3 client
+that returns paginated responses and assert that every topic /
+subscription across all pages is collected.
+"""
+import unittest.mock
+
+import boto3
+import moto
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal pacu_main stand-in that satisfies the code paths
+# exercised by sns__enum.main().
+# ---------------------------------------------------------------------------
+
+def _make_mock_session(region: str = "us-east-1"):
+    """Return a lightweight mock that pacu_main.get_boto3_client() uses."""
+    session = boto3.Session(
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+        aws_session_token="testing",
+        region_name=region,
+    )
+    return session
+
+
+def _make_pacu_main(boto3_client_fn, session_data=None):
+    """
+    Construct a minimal pacu_main duck-typed object that sns__enum.main()
+    will accept without importing the real pacu.Main (which needs the full
+    DB stack).
+    """
+    pacu_session = unittest.mock.MagicMock()
+    pacu_session.SNS = {}
+
+    pacu_main = unittest.mock.MagicMock()
+    pacu_main.get_active_session.return_value = pacu_session
+    pacu_main.get_boto3_client.side_effect = boto3_client_fn
+    pacu_main.get_regions.return_value = ["us-east-1"]
+    pacu_main.print = lambda *a, **kw: None  # silence output in tests
+    pacu_main.key_info = unittest.mock.MagicMock()
+    pacu_main.fetch_data = unittest.mock.MagicMock()
+    return pacu_main
+
+
+# ---------------------------------------------------------------------------
+# Test 1: list_topics pagination — >100 topics (two pages) all enumerated
+# ---------------------------------------------------------------------------
+
+@moto.mock_aws
+def test_list_topics_follows_next_token():
+    """
+    Create 105 SNS topics via moto (which respects the 100-item page cap),
+    run sns__enum.main(), and assert all 105 are present in the result.
+    """
+    from pacu.modules.sns__enum.main import main
+
+    region = "us-east-1"
+    client = boto3.client(
+        "sns",
+        region_name=region,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+        aws_session_token="testing",
+    )
+
+    topic_arns = []
+    for i in range(105):
+        resp = client.create_topic(Name=f"test-topic-{i:03d}")
+        topic_arns.append(resp["TopicArn"])
+
+    # Verify moto actually paginates (sanity-check on the fixture itself).
+    first_page = client.list_topics()
+    assert len(first_page["Topics"]) == 100, (
+        "moto did not paginate list_topics at 100; "
+        "adjust topic count or check moto version"
+    )
+    assert "NextToken" in first_page
+
+    def get_client(service, reg):
+        assert service == "sns"
+        return client
+
+    pacu_main = _make_pacu_main(get_client)
+    result = main(["--regions", region], pacu_main)
+
+    reported = result["sns"][region]
+    assert len(reported) == 105, (
+        f"Expected 105 topics, got {len(reported)}. "
+        "Pagination via NextToken was likely not followed."
+    )
+    for arn in topic_arns:
+        assert arn in reported, f"Topic {arn} missing from enumeration result"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: list_subscriptions_by_topic pagination — >100 subs all enumerated
+# ---------------------------------------------------------------------------
+
+@moto.mock_aws
+def test_list_subscriptions_by_topic_follows_next_token():
+    """
+    Create 1 SNS topic and 105 email subscriptions, run sns__enum.main(),
+    and assert all 105 subscribers appear in the result.
+
+    Note: moto paginates list_subscriptions_by_topic at 100.
+    """
+    from pacu.modules.sns__enum.main import main
+
+    region = "us-east-1"
+    client = boto3.client(
+        "sns",
+        region_name=region,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+        aws_session_token="testing",
+    )
+
+    topic_arn = client.create_topic(Name="sub-pagination-topic")["TopicArn"]
+
+    for i in range(105):
+        client.subscribe(
+            TopicArn=topic_arn,
+            Protocol="email",
+            Endpoint=f"user{i:03d}@example.com",
+        )
+
+    # Sanity-check: moto must paginate at 100.
+    first_page = client.list_subscriptions_by_topic(TopicArn=topic_arn)
+    assert len(first_page["Subscriptions"]) == 100, (
+        "moto did not paginate list_subscriptions_by_topic at 100; "
+        "adjust subscriber count or check moto version"
+    )
+    assert "NextToken" in first_page
+
+    def get_client(service, reg):
+        assert service == "sns"
+        return client
+
+    pacu_main = _make_pacu_main(get_client)
+    result = main(["--regions", region], pacu_main)
+
+    subscribers = result["sns"][region][topic_arn]["Subscribers"]
+    assert len(subscribers) == 105, (
+        f"Expected 105 subscribers, got {len(subscribers)}. "
+        "Pagination via NextToken for list_subscriptions_by_topic was likely not followed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: baseline — fewer than 100 topics, no NextToken in play
+# ---------------------------------------------------------------------------
+
+@moto.mock_aws
+def test_single_page_topics_unaffected():
+    """
+    Smoke test: 3 topics, no pagination needed.  Ensures the refactor did
+    not break the common (< 100 topics) case.
+    """
+    from pacu.modules.sns__enum.main import main
+
+    region = "us-east-1"
+    client = boto3.client(
+        "sns",
+        region_name=region,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+        aws_session_token="testing",
+    )
+
+    arns = []
+    for i in range(3):
+        arns.append(client.create_topic(Name=f"small-topic-{i}")["TopicArn"])
+
+    def get_client(service, reg):
+        return client
+
+    pacu_main = _make_pacu_main(get_client)
+    result = main(["--regions", region], pacu_main)
+
+    assert len(result["sns"][region]) == 3
+    for arn in arns:
+        assert arn in result["sns"][region]
+
+
+# ---------------------------------------------------------------------------
+# Test 4: empty region — result must not include the region key
+# ---------------------------------------------------------------------------
+
+@moto.mock_aws
+def test_empty_region_excluded_from_result():
+    """
+    When no topics exist in a region the module should not store an empty
+    dict for that region (existing behaviour, must remain unchanged).
+    """
+    from pacu.modules.sns__enum.main import main
+
+    region = "us-east-1"
+    client = boto3.client(
+        "sns",
+        region_name=region,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+        aws_session_token="testing",
+    )
+
+    def get_client(service, reg):
+        return client
+
+    pacu_main = _make_pacu_main(get_client)
+    result = main(["--regions", region], pacu_main)
+
+    assert region not in result["sns"], (
+        "Empty region should be excluded from result dict"
+    )


### PR DESCRIPTION
## Summary

`sns__enum` called `list_topics()` and `list_subscriptions_by_topic()` exactly
once per region/topic, silently capping enumeration at 100 items per call and
producing false-negatives in accounts with more than 100 SNS topics or more than
100 subscriptions on a single topic.

## Problem / Motivation

The AWS SNS API paginates `list_topics` at 100 topics per response and
`list_subscriptions_by_topic` at 100 subscriptions per response. Prior to this
fix, both calls were made exactly once — the `NextToken` field in the response
was ignored. In any AWS account where either threshold is crossed, `sns__enum`
would silently under-report:

- A topology with 150 SNS topics would show 100. The 50 missing topics — and all
  their subscribers — would never be examined.
- A single high-fan-out topic with 150 confirmed subscribers would report only
  100 subscribers.

This is a direct enumeration false-negative: an operator running Pacu in a
large-scale AWS environment receives a clean-looking report that materially
misrepresents the SNS attack surface. From a threat-modelling perspective the
missed topics could include SNS→Lambda chains, cross-account notification
channels, or data-exfiltration primitives that a red-team or a defender needs to
account for (MITRE ATT&CK T1526 — Cloud Service Discovery).

The pattern is identical to the bug fixed in PR #503 and mirrors pagination
already correctly implemented in `codebuild__enum` (`nextToken`) and
`dynamodb__enum` (`LastEvaluatedTableName`).

## Change

`pacu/modules/sns__enum/main.py`:

- Replaced the single `client.list_topics()` call with a `NextToken` while-loop
  that accumulates all topic ARNs into `all_topics` before iterating.
- Replaced the single `client.list_subscriptions_by_topic()` call per topic with
  a `NextToken` while-loop that accumulates all subscriptions into
  `all_subscriptions` before appending to the result.
- Both loops guard with `and response["NextToken"] != ""`. A bare
  `while "NextToken" in response` does not terminate when the terminal page
  carries an empty token instead of omitting the key — the same defect class as
  #503. This matches the idiom in `glue__enum/main.py:56` and
  `transfer_family__enum/main.py:44`.
- No changes to data structures, summary output, or session-persistence logic;
  the fix is narrowly scoped to the two pagination gaps.

`pacu/modules/sns__enum/tests/test_sns__enum.py` (new file):

- Five pytest tests, four backed by `moto.mock_aws`:
  1. `test_list_topics_follows_next_token` — creates 105 topics, asserts all 105
     are in the result (fails on the unfixed code).
  2. `test_list_subscriptions_by_topic_follows_next_token` — creates 1 topic with
     105 subscriptions, asserts all 105 subscribers are collected (fails on the
     unfixed code).
  3. `test_single_page_topics_unaffected` — smoke test confirming the common
     (<100 topics) path is unchanged.
  4. `test_empty_region_excluded_from_result` — confirms the existing behaviour
     of dropping empty regions is preserved.
  5. `test_empty_next_token_terminates_pagination` — a fake client whose last
     page returns `NextToken: ""`, with a hard call cap so a regression fails
     fast instead of hanging the suite.

The tests live in the module's `tests/` subdir, matching the existing convention
used by `cfn__resource_injection` and `cognito__attack`. `pyproject.toml`'s
`testpaths` already includes `pacu/modules`, so `pytest` / `python -m pytest`
discovers them automatically. Note: the `Makefile` `test` target currently only
points at `./tests` and the cfn lambda tests, so `make test` will not pick these
up as-is — if maintainers prefer, the `test` target can be widened, but that is
out of scope here.

## Security Rationale

Incomplete cloud asset enumeration is a well-documented source of security
blind-spots. An assessor who misses 50 SNS topics in a large AWS account may
overlook notification-triggered Lambda functions, cross-account delivery
channels, or subscriber endpoints that are in scope for privilege-escalation or
data-exfiltration analysis. Pacu is a red-team tool; its enumeration modules are
the foundation on which every subsequent attack module depends. A false-negative
here propagates silently downstream.

This class of bug — assuming a single paginated API response is exhaustive —
maps to incomplete enumeration under MITRE ATT&CK T1526 and is the exact defect
pattern documented in CWE-390 (Detection of Error Condition Without Action) when
the `NextToken` presence is passively ignored.

## Testing / Validation

```
# Environment: Python 3.14.5, moto 5.2.3, boto3 1.28.85, pytest 9.1.1
# Isolation: fresh venv, no live AWS credentials. Not run against a real AWS account.

$ python -m pytest pacu/modules/sns__enum/tests/test_sns__enum.py -q
5 passed

# Same tests against the main.py currently on master:
FAILED test_list_topics_follows_next_token
FAILED test_list_subscriptions_by_topic_follows_next_token
FAILED test_empty_next_token_terminates_pagination
3 failed, 2 passed

# Full discovery per pyproject.toml testpaths:
$ python -m pytest -q
61 passed
```

The three pagination tests fail deterministically against the pre-fix code and
pass deterministically against the fix. The two behaviour-preservation tests
(single page, empty region) pass in both directions.

Note: the `Makefile` `test` target CI runs points only at `./tests` and the cfn
lambda tests (53 of the 61 above), so CI will not execute these tests as-is.
Switching it to `python3 -m pytest` picks up all 61 and passes clean. Left
unchanged here as a maintainer call.
