### PR TITLE
Use dict.get method for PublicIpAddress retrieval

### DIFF
--- a/pacu/modules/ec2__enum/main.py
+++ b/pacu/modules/ec2__enum/main.py
@@ -261,7 +261,7 @@ def main(args, pacu_main):
                     response = client.describe_instances(MaxResults=1000,NextToken=next_token)
                     for reservation in response['Reservations']:
                         for instance in reservation['Instances']:
-                            public = instance["PublicIpAddress"]
+                            public = instance.get("PublicIpAddress")
                             if public:
                                 public_ips.append(public)
                 if 'NextToken' in response:


### PR DESCRIPTION
Direct dictionary access when processing
instances returned from paginated results caused a KeyError if there was no public IP. Replaced with dict.get() retrieval