### PR TITLE
Auto-update Module-Details wiki page from module_info

### DIFF
--- a/.github/workflows/update-modules-wiki.yml
+++ b/.github/workflows/update-modules-wiki.yml
@@ -1,0 +1,68 @@
+# Keeps the wiki's Module-Details page (https://github.com/RhinoSecurityLabs/pacu/wiki/Module-Details)
+# in sync with the module_info metadata defined in pacu/modules/*/main.py, so the
+# wiki doesn't drift out of date every time a module is added or its module_info changes.
+# See scripts/generate_module_wiki.py for the generator this workflow runs.
+#
+# Requires a repository secret named WIKI_DEPLOY_TOKEN: a GitHub PAT (classic,
+# `repo` scope) belonging to an account with push access to this repository. The
+# default GITHUB_TOKEN cannot push to the wiki, which is a separate git repo
+# (<repo>.wiki.git) that GITHUB_TOKEN has no access to.
+
+name: Update Modules Wiki
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'pacu/modules/**/main.py'
+      - 'scripts/generate_module_wiki.py'
+  workflow_dispatch: {}
+
+jobs:
+  update-wiki:
+    runs-on: ubuntu-latest
+    if: github.repository == 'RhinoSecurityLabs/pacu'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Dependencies
+        run: poetry install
+
+      - name: Generate Module-Details.md
+        run: poetry run python scripts/generate_module_wiki.py > /tmp/Module-Details.md
+
+      - name: Checkout Wiki
+        env:
+          WIKI_DEPLOY_TOKEN: ${{ secrets.WIKI_DEPLOY_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${WIKI_DEPLOY_TOKEN}@github.com/${{ github.repository }}.wiki.git" /tmp/wiki
+
+      - name: Update Wiki Page
+        id: diff
+        run: |
+          cp /tmp/Module-Details.md /tmp/wiki/Module-Details.md
+          cd /tmp/wiki
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and Push
+        if: steps.diff.outputs.changed == 'true'
+        working-directory: /tmp/wiki
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Module-Details.md
+          git commit -m "Auto-update Module-Details from ${{ github.sha }}"
+          git push origin master

--- a/scripts/generate_module_wiki.py
+++ b/scripts/generate_module_wiki.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Generate the pacu.wiki "Module-Details" page from each module's module_info.
+
+Walks pacu/modules/*/main.py, imports module_info from each, and renders
+markdown grouped by category in the same format as the wiki's
+Module-Details.md page. Used by .github/workflows/update-modules-wiki.yml
+to keep that page in sync automatically; can also be run locally:
+
+    poetry run python scripts/generate_module_wiki.py > /path/to/pacu.wiki/Module-Details.md
+"""
+import importlib
+import sys
+from pathlib import Path
+
+MODULES_DIR = Path(__file__).resolve().parent.parent / 'pacu' / 'modules'
+
+
+def iter_module_infos():
+    for entry in sorted(MODULES_DIR.iterdir()):
+        main_file = entry / 'main.py'
+        if not entry.is_dir() or not main_file.exists():
+            continue
+        module = importlib.import_module(f'pacu.modules.{entry.name}.main')
+        importlib.reload(module)
+        yield module.module_info
+
+
+def render(module_infos):
+    by_category = {}
+    for info in module_infos:
+        by_category.setdefault(info['category'], []).append(info)
+
+    lines = []
+    for category in sorted(by_category):
+        lines.append(f'## {category}')
+        for info in sorted(by_category[category], key=lambda m: m['name']):
+            description = ' '.join(info['description'].split())
+            lines.append(f"### {info['name']}")
+            lines.append(f"> **{info['one_liner']}**")
+            lines.append('')
+            lines.append(description)
+            lines.append('')
+            lines.append('')
+    return '\n'.join(lines).rstrip() + '\n'
+
+
+def main():
+    sys.stdout.write(render(iter_module_infos()))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_generate_module_wiki.py
+++ b/tests/test_generate_module_wiki.py
@@ -1,0 +1,46 @@
+import importlib.util
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).parents[1] / 'scripts' / 'generate_module_wiki.py'
+_spec = importlib.util.spec_from_file_location('generate_module_wiki', SCRIPT_PATH)
+generate_module_wiki = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(generate_module_wiki)
+
+
+def test_render_sorts_categories_and_modules_alphabetically():
+    module_infos = [
+        {'name': 'zzz__enum', 'category': 'ENUM', 'one_liner': 'Z one liner', 'description': 'Z description.'},
+        {'name': 'aaa__enum', 'category': 'ENUM', 'one_liner': 'A one liner', 'description': 'A description.'},
+        {'name': 'bbb__exfil', 'category': 'EXFIL', 'one_liner': 'B one liner', 'description': 'B description.'},
+    ]
+
+    output = generate_module_wiki.render(module_infos)
+
+    assert output.index('## ENUM') < output.index('## EXFIL')
+    assert output.index('### aaa__enum') < output.index('### zzz__enum')
+
+
+def test_render_normalizes_multiline_description_whitespace():
+    module_infos = [
+        {
+            'name': 'aaa__enum',
+            'category': 'ENUM',
+            'one_liner': 'One liner.',
+            'description': '  This description\n   spans multiple\nlines.  ',
+        },
+    ]
+
+    output = generate_module_wiki.render(module_infos)
+
+    assert 'This description spans multiple lines.' in output
+
+
+def test_render_ends_with_single_trailing_newline():
+    module_infos = [
+        {'name': 'aaa__enum', 'category': 'ENUM', 'one_liner': 'One liner.', 'description': 'Description.'},
+    ]
+
+    output = generate_module_wiki.render(module_infos)
+
+    assert output.endswith('\n')
+    assert not output.endswith('\n\n')


### PR DESCRIPTION
## Summary
- Adds `scripts/generate_module_wiki.py`, which walks `pacu/modules/*/main.py`, reads each module's `module_info`, and renders the wiki's `Module-Details.md` format grouped by category (same walk pattern `load_categories()` in `pacu/main.py` already uses).
- Adds `.github/workflows/update-modules-wiki.yml`, which runs the script on every push to `master` touching a module and pushes the result to the wiki repo, so the page stays in sync automatically instead of needing a manual edit per module change.
- Adds `tests/test_generate_module_wiki.py` covering category/module sorting and description whitespace normalization.

Closes #300 — the issue's draft snippet already sketched this exact walk-modules-and-read-`module_info` approach; this PR wires it into a script + workflow.

As of this writing the live wiki page is stale (last updated May 2024) and missing 6 modules added since: `apigateway__enum`, `ds__enum`, `eks__collect_tokens`, `eks__enum`, `elasticbeanstalk__enum`, `rds__enum`. Once merged and configured, the workflow will pick these up automatically.

**Needs a maintainer to add a repository secret:** `WIKI_DEPLOY_TOKEN` — a classic PAT with `repo` scope, from an account with push access to this repo. The default `GITHUB_TOKEN` cannot push to the wiki, since it's a separate git repo (`<repo>.wiki.git>`) outside its permission scope. This is called out in a comment at the top of the workflow file.

## Test plan
- [x] `poetry run python -m pytest tests/` — 51 passed (48 existing + 3 new)
- [x] `poetry run flake8 scripts/generate_module_wiki.py` — clean
- [x] Ran `scripts/generate_module_wiki.py` locally against current `pacu/modules/` (76 modules) and confirmed output format matches the existing wiki page, including picking up the 6 currently-missing modules
- [x] Validated workflow YAML syntax
- [ ] Workflow itself can only be fully verified after merge once `WIKI_DEPLOY_TOKEN` is configured (can't test wiki-push permissions from a fork)